### PR TITLE
状態更新基盤作成とスキルカード使用によるおおよその更新処理作成

### DIFF
--- a/src/data/card/index.ts
+++ b/src/data/card/index.ts
@@ -1,4 +1,4 @@
-import { CardDefinition } from "../../types";
+import { CardDefinition, ProducePlan } from "../../types";
 
 export const findCardDataById = (
   id: CardDefinition["id"],
@@ -11,6 +11,18 @@ export const getCardDataById = (id: CardDefinition["id"]): CardDefinition => {
   }
   return card;
 };
+
+/** 「ランダムな強化済みスキルカード（SSR）を、手札に生成」用の候補を返す */
+export const filterGeneratableCardsData = (
+  producePlanKind: ProducePlan["kind"],
+) =>
+  cards.filter(
+    (card) =>
+      card.cardProviderKind === "others" &&
+      (card.cardPossessionKind === "free" ||
+        card.cardPossessionKind === producePlanKind) &&
+      card.rarity === "ssr",
+  );
 
 /**
  * スキルカードデータの定義
@@ -2116,7 +2128,7 @@ export const cards: CardDefinition[] = [
     },
   },
   {
-    id: "zonzaikan",
+    id: "sonzaikan",
     name: "存在感",
     cardPossessionKind: "sense",
     cardProviderKind: "others",
@@ -3467,7 +3479,7 @@ export const cards: CardDefinition[] = [
         {
           kind: "performLeveragingVitality",
           reductionKind: "zero",
-          percentage: 250,
+          percentage: 160,
         },
       ],
       usableOncePerLesson: true,
@@ -3835,9 +3847,9 @@ export const cards: CardDefinition[] = [
     nonDuplicative: true,
     rarity: "ssr",
     base: {
-      cost: { kind: "goodCondition", value: 2 },
+      cost: { kind: "positiveImpression", value: 2 },
       effects: [
-        { kind: "increaseTurns", amount: 1 },
+        { kind: "increaseRemainingTurns", amount: 1 },
         {
           kind: "getModifier",
           modifier: {
@@ -3850,9 +3862,9 @@ export const cards: CardDefinition[] = [
       usableOncePerLesson: true,
     },
     enhanced: {
-      cost: { kind: "goodCondition", value: 1 },
+      cost: { kind: "positiveImpression", value: 1 },
       effects: [
-        { kind: "increaseTurns", amount: 1 },
+        { kind: "increaseRemainingTurns", amount: 1 },
         {
           kind: "getModifier",
           modifier: {

--- a/src/data/character/index.ts
+++ b/src/data/character/index.ts
@@ -1,5 +1,20 @@
 import { CharacterDefinition } from "../../types";
 
+export const findCharacterDataById = (
+  id: CharacterDefinition["id"],
+): CharacterDefinition | undefined =>
+  characters.find((character) => character.id === id);
+
+export const getCharacterDataById = (
+  id: CharacterDefinition["id"],
+): CharacterDefinition => {
+  const character = findCharacterDataById(id);
+  if (!character) {
+    throw new Error(`Character not found: ${id}`);
+  }
+  return character;
+};
+
 /**
  * アイドル個性の定義
  *
@@ -32,8 +47,8 @@ export const characters: CharacterDefinition[] = [
     maxLife: 31,
   },
   {
-    id: "arimuranao",
-    firstName: "奈央",
+    id: "arimuramao",
+    firstName: "麻央",
     lastName: "有村",
     maxLife: 31,
   },

--- a/src/data/idol/index.test.ts
+++ b/src/data/idol/index.test.ts
@@ -3,6 +3,14 @@ import { characters } from "../character";
 import { producerItems } from "../producer-item";
 import { idols } from "./index";
 
+test("any id is not duplicated", () => {
+  let ids: string[] = [];
+  for (const idol of idols) {
+    expect(ids).not.toContain(idol.id);
+    ids = [...ids, idol.id];
+  }
+});
+
 // 存在するデータのパターンから、法則を推測し、それに適合しているかでデータの検証を行う。
 // 今後、新しいデータの出現によって、法則が崩れてテストが成立しなくなる可能性はある。
 for (const idol of idols) {

--- a/src/data/idol/index.ts
+++ b/src/data/idol/index.ts
@@ -1,5 +1,17 @@
 import { IdolDefinition } from "../../types";
 
+export const findIdolDataById = (
+  id: IdolDefinition["id"],
+): IdolDefinition | undefined => idols.find((idol) => idol.id === id);
+
+export const getIdolDataById = (id: IdolDefinition["id"]): IdolDefinition => {
+  const card = findIdolDataById(id);
+  if (!card) {
+    throw new Error(`Idol not found: ${id}`);
+  }
+  return card;
+};
+
 /**
  * プロデュースアイドルの定義
  *
@@ -10,7 +22,9 @@ import { IdolDefinition } from "../../types";
  * - TODO: eslint
  */
 export const idols: IdolDefinition[] = [
+  // TODO: さきのBoom Boom Powを足す
   {
+    id: "hanamisaki-ssr-1",
     characterId: "hanamisaki",
     producePlan: {
       kind: "sense",
@@ -22,6 +36,7 @@ export const idols: IdolDefinition[] = [
     title: "Fighting My Way",
   },
   {
+    id: "hanamisaki-sr-1",
     characterId: "hanamisaki",
     producePlan: {
       kind: "sense",
@@ -33,6 +48,7 @@ export const idols: IdolDefinition[] = [
     title: "わたしが一番！",
   },
   {
+    id: "hanamisaki-r-1",
     characterId: "hanamisaki",
     producePlan: {
       kind: "sense",
@@ -44,6 +60,7 @@ export const idols: IdolDefinition[] = [
     title: "学園生活",
   },
   {
+    id: "tsukimuratemari-ssr-2",
     characterId: "tsukimuratemari",
     producePlan: {
       kind: "logic",
@@ -55,6 +72,7 @@ export const idols: IdolDefinition[] = [
     title: "アイヴイ",
   },
   {
+    id: "tsukimuratemari-ssr-1",
     characterId: "tsukimuratemari",
     producePlan: {
       kind: "sense",
@@ -66,6 +84,7 @@ export const idols: IdolDefinition[] = [
     title: "Luna say maybe",
   },
   {
+    id: "tsukimuratemari-sr-1",
     characterId: "tsukimuratemari",
     producePlan: {
       kind: "sense",
@@ -77,6 +96,7 @@ export const idols: IdolDefinition[] = [
     title: "一匹狼",
   },
   {
+    id: "tsukimuratemari-r-1",
     characterId: "tsukimuratemari",
     producePlan: {
       kind: "sense",
@@ -88,6 +108,7 @@ export const idols: IdolDefinition[] = [
     title: "学園生活",
   },
   {
+    id: "fujitakotone-ssr-2",
     characterId: "fujitakotone",
     producePlan: {
       kind: "sense",
@@ -99,6 +120,7 @@ export const idols: IdolDefinition[] = [
     title: "Yellow Big Bang！",
   },
   {
+    id: "fujitakotone-ssr-1",
     characterId: "fujitakotone",
     producePlan: {
       kind: "logic",
@@ -110,6 +132,7 @@ export const idols: IdolDefinition[] = [
     title: "世界一可愛い私",
   },
   {
+    id: "fujitakotone-sr-1",
     characterId: "fujitakotone",
     producePlan: {
       kind: "logic",
@@ -121,6 +144,7 @@ export const idols: IdolDefinition[] = [
     title: "カワイイ♡はじめました",
   },
   {
+    id: "fujitakotone-r-1",
     characterId: "fujitakotone",
     producePlan: {
       kind: "logic",
@@ -132,7 +156,8 @@ export const idols: IdolDefinition[] = [
     title: "学園生活",
   },
   {
-    characterId: "arimuranao",
+    id: "arimuramao-ssr-1",
+    characterId: "arimuramao",
     producePlan: {
       kind: "sense",
       recommendedEffect: "goodCondition",
@@ -143,7 +168,8 @@ export const idols: IdolDefinition[] = [
     title: "Fluorite",
   },
   {
-    characterId: "arimuranao",
+    id: "arimuramao-sr-1",
+    characterId: "arimuramao",
     producePlan: {
       kind: "sense",
       recommendedEffect: "goodCondition",
@@ -154,7 +180,8 @@ export const idols: IdolDefinition[] = [
     title: "はじまりはカッコよく",
   },
   {
-    characterId: "arimuranao",
+    id: "arimuramao-r-1",
+    characterId: "arimuramao",
     producePlan: {
       kind: "sense",
       recommendedEffect: "goodCondition",
@@ -165,6 +192,7 @@ export const idols: IdolDefinition[] = [
     title: "学園生活",
   },
   {
+    id: "katsuragiririya-ssr-1",
     characterId: "katsuragiririya",
     producePlan: {
       kind: "logic",
@@ -176,6 +204,7 @@ export const idols: IdolDefinition[] = [
     title: "白線",
   },
   {
+    id: "katsuragiririya-sr-1",
     characterId: "katsuragiririya",
     producePlan: {
       kind: "logic",
@@ -187,6 +216,7 @@ export const idols: IdolDefinition[] = [
     title: "一つ踏み出した先に",
   },
   {
+    id: "katsuragiririya-r-1",
     characterId: "katsuragiririya",
     producePlan: {
       kind: "logic",
@@ -198,6 +228,7 @@ export const idols: IdolDefinition[] = [
     title: "学園生活",
   },
   {
+    id: "kuramotochina-ssr-1",
     characterId: "kuramotochina",
     producePlan: {
       kind: "logic",
@@ -209,6 +240,7 @@ export const idols: IdolDefinition[] = [
     title: "Wonder Scale",
   },
   {
+    id: "kuramotochina-sr-1",
     characterId: "kuramotochina",
     producePlan: {
       kind: "logic",
@@ -220,6 +252,7 @@ export const idols: IdolDefinition[] = [
     title: "胸を張って一歩ずつ",
   },
   {
+    id: "kuramotochina-r-1",
     characterId: "kuramotochina",
     producePlan: {
       kind: "logic",
@@ -231,6 +264,7 @@ export const idols: IdolDefinition[] = [
     title: "学園生活",
   },
   {
+    id: "shiunsumika-ssr-1",
     characterId: "shiunsumika",
     producePlan: {
       kind: "sense",
@@ -242,6 +276,7 @@ export const idols: IdolDefinition[] = [
     title: "Time-Lie-One-Step",
   },
   {
+    id: "shiunsumika-sr-1",
     characterId: "shiunsumika",
     producePlan: {
       kind: "sense",
@@ -253,6 +288,7 @@ export const idols: IdolDefinition[] = [
     title: "夢へのリスタート",
   },
   {
+    id: "shiunsumika-r-1",
     characterId: "shiunsumika",
     producePlan: {
       kind: "sense",
@@ -264,6 +300,7 @@ export const idols: IdolDefinition[] = [
     title: "学園生活",
   },
   {
+    id: "shinosawahiro-ssr-1",
     characterId: "shinosawahiro",
     producePlan: {
       kind: "logic",
@@ -275,6 +312,7 @@ export const idols: IdolDefinition[] = [
     title: "光景",
   },
   {
+    id: "shinosawahiro-sr-1",
     characterId: "shinosawahiro",
     producePlan: {
       kind: "logic",
@@ -286,6 +324,7 @@ export const idols: IdolDefinition[] = [
     title: "一番向いてないこと",
   },
   {
+    id: "shinosawahiro-r-1",
     characterId: "shinosawahiro",
     producePlan: {
       kind: "logic",
@@ -297,6 +336,7 @@ export const idols: IdolDefinition[] = [
     title: "学園生活",
   },
   {
+    id: "hanamiume-ssr-1",
     characterId: "hanamiume",
     producePlan: {
       kind: "logic",
@@ -308,6 +348,7 @@ export const idols: IdolDefinition[] = [
     title: "The Rolling Riceball",
   },
   {
+    id: "hanamiume-sr-1",
     characterId: "hanamiume",
     producePlan: {
       kind: "logic",
@@ -319,6 +360,7 @@ export const idols: IdolDefinition[] = [
     title: "アイドル、はじめっ！",
   },
   {
+    id: "hanamiume-r-1",
     characterId: "hanamiume",
     producePlan: {
       kind: "logic",

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,10 +10,195 @@
 
 // TODO: Pドリンク
 // TODO: サポートアビリティ
-// TODO: レッスン中
+// TODO: レッスン内の応援/トラブル
+// TODO: レッスン履歴
+// TODO: データの永続化サポート
 // TODO: コンテスト、後のためのメモ
 //       - AIの挙動を解読する必要がある、多少眺めた限りだとわからなかった
 //       - レッスン中に放置するとカードがうっすら光っておすすめカードを教えてくれるが、それがコンテストと同じAIかもしれない
 //         - もしそうだとすると、AIはサーバ側ではなくてクライアント側が計算しているのかもしれない
 
-import {} from "./types";
+import { getCardDataById } from "./data/card";
+import { getCharacterDataById } from "./data/character";
+import { getIdolDataById } from "./data/idol";
+import { getProducerItemDataById } from "./data/producer-item";
+import {
+  Card,
+  CardInProduction,
+  GetRandom,
+  IdGenerator,
+  Idol,
+  IdolInProduction,
+  Lesson,
+  LessonGamePlay,
+  LessonUpdateQuery,
+} from "./types";
+import {
+  drawCardsOnLessonStart,
+  previewCardUsage,
+  useCard,
+} from "./lesson-mutation";
+import { handSizeOnLessonStart, patchUpdates } from "./models";
+
+//
+// UI側での想定の呼び出し方
+//
+// ゲーム開始:
+// ```
+// const lessonGamePlay = createLessonGamePlay();
+// ```
+//
+// ターン開始:
+// ```
+// const newLessonGamePlay = startLessonTurn(lessonGamePlay);
+// const recentUpdates = newLessonGamePlay.updates.slice(lessonGamePlay.updates.length);
+// set状態遷移アニメーション(recentUpdates);
+// // アニメーション設定がある場合は、それが終わるまで表示上反映されない
+// setLesson(最新のLessonの状態を返す(newLessonGamePlay));
+// ```
+//
+// カード選択してスキルカード使用プレビュー:
+// ```
+// // 使用できない状況のカードでもプレビューはできる、また、連鎖するPアイテム効果などはプレビュー表示されないなど実際のカード使用処理とは違うところが多いので別にした方が良い
+// const newLessonGamePlay = previewCardUsage(lessonGamePlay, cardInHandIndex);
+// const recentUpdates = newLessonGamePlay.updates.slice(lessonGamePlay.updates.length);
+// // プレビューは差分表示されるがアニメーションはされない
+// const setプレビュー用Updates(recentUpdates)
+// ```
+//
+// 手札のスキルカードを表示:
+// ```
+// // スキルカードIDと選択可能かの状態のリスト
+// const 手札リスト = 手札を取得する(lessonGamePlay);
+// const set手札リスト(手札リスト)
+// ```
+//
+// カード選択してスキルカード使用:
+// ```
+// const newLessonGamePlay = useCard(lessonGamePlay, cardInHandIndex);
+// const recentUpdates = newLessonGamePlay.updates.slice(lessonGamePlay.updates.length);
+// set状態遷移アニメーション(recentUpdates);
+// // アニメーション設定がある場合は、それが終わるまで表示上反映されない
+// setLesson(最新のLessonの状態を返す(newLessonGamePlay));
+// ```
+//
+
+/**
+ * レッスンのターンを開始する
+ *
+ * - レッスン開始時に関わる処理も含む
+ */
+export const startLessonTurn = (
+  lessonGamePlay: LessonGamePlay,
+): LessonGamePlay => {
+  let updatesList = [lessonGamePlay.updates];
+  let lesson = lessonGamePlay.initialLesson;
+  let historyResultIndex = 1;
+
+  // TODO: ターン数増加
+
+  // TODO: 1ターン目なら、レッスン開始時トリガー
+
+  // 手札を山札から引く
+  lesson = patchUpdates(lesson, updatesList[updatesList.length - 1]);
+  updatesList = [
+    ...updatesList,
+    drawCardsOnLessonStart(lesson, {
+      // 一時的なメモ: 次のターンにスキルカードを引く効果は、本家を見ると手札に後で足すアニメーションなので、この後のレッスン開始トリガーで別にやってそう
+      count: handSizeOnLessonStart,
+      historyResultIndex: historyResultIndex,
+      getRandom: lessonGamePlay.getRandom,
+    }),
+  ];
+  historyResultIndex++;
+
+  // TODO: ターン開始時トリガー
+
+  return {
+    ...lessonGamePlay,
+    updates: updatesList.flat(),
+  };
+};
+
+// const previewCardUsage = () => {};
+
+/**
+ * スキルカードを使用する
+ *
+ * @param selectedCardInHandIndex 選択した手札のインデックス、使用可能な手札を渡す必要がある
+ */
+export const playCard = (
+  lessonGamePlay: LessonGamePlay,
+  selectedCardInHandIndex: number,
+): LessonGamePlay => {
+  let updatesList = [lessonGamePlay.updates];
+  let lesson = lessonGamePlay.initialLesson;
+  let historyResultIndex = 1;
+
+  // TODO: スキルカード使用数1以上か検証
+
+  // TODO: スキルカード使用数消費
+
+  lesson = patchUpdates(lesson, updatesList[updatesList.length - 1]);
+  const result = useCard(lesson, historyResultIndex, {
+    getRandom: lessonGamePlay.getRandom,
+    idGenerator: lessonGamePlay.idGenerator,
+    selectedCardInHandIndex,
+  });
+  updatesList = [...updatesList, result.updates];
+  historyResultIndex = result.nextHistoryResultIndex;
+
+  // TODO: スコアパーフェクト達成によるゲーム終了判定、ターン終了処理を待たずに即座に終了している
+
+  // TODO: スキルカード使用数0ならターン終了
+
+  return {
+    ...lessonGamePlay,
+    updates: updatesList.flat(),
+  };
+};
+
+/**
+ * レッスンのターンを終了する
+ *
+ * - レッスン終了時に関わる処理は、現在はなさそう
+ */
+const endLessonTurn = (lessonGamePlay: LessonGamePlay): LessonGamePlay => {
+  let updatesList = [lessonGamePlay.updates];
+  let lesson = lessonGamePlay.initialLesson;
+  let historyResultIndex = 1;
+
+  // TODO: ターン終了時トリガー
+
+  // TODO: 応援/トラブルトリガー
+
+  // TODO: 手札を捨てる
+
+  // TODO: ターン数によるゲーム終了判定
+
+  return {
+    ...lessonGamePlay,
+    updates: updatesList.flat(),
+  };
+};
+
+/**
+ * ターンをスキップする
+ *
+ * - 本家のボタンについているラベルは「Skip」
+ * - プレビューはない
+ */
+export const skipTurn = (lessonGamePlay: LessonGamePlay): LessonGamePlay => {
+  let updatesList = [lessonGamePlay.updates];
+  let lesson = lessonGamePlay.initialLesson;
+  let historyResultIndex = 1;
+
+  // TODO: スキルカード使用数1以上必要
+
+  // TODO: 体力回復
+
+  return {
+    ...lessonGamePlay,
+    updates: updatesList.flat(),
+  };
+};

--- a/src/lesson-mutation.test.ts
+++ b/src/lesson-mutation.test.ts
@@ -1,0 +1,2407 @@
+import {
+  Card,
+  CardDefinition,
+  CardInProduction,
+  Idol,
+  IdolDefinition,
+  IdolInProduction,
+  Lesson,
+} from "./types";
+import { cards, getCardDataById } from "./data/card";
+import {
+  addCardsToHandOrDiscardPile,
+  calculatePerformingScoreEffect,
+  calculatePerformingVitalityEffect,
+  canApplyEffect,
+  canUseCard,
+  createCardPlacementDiff,
+  drawCardsFromDeck,
+  drawCardsOnLessonStart,
+  useCard,
+  validateCostComsumution,
+} from "./lesson-mutation";
+import {
+  createIdolInProduction,
+  createLesson,
+  patchUpdates,
+  prepareCardsForLesson,
+} from "./models";
+import { createIdGenerator } from "./utils";
+
+describe("drawCardsFromDeck", () => {
+  test("山札がなくならない状態で1枚引いた時、1枚引けて、山札が1枚減る", () => {
+    const deck = ["1", "2", "3"];
+    const { drawnCards, deck: newDeck } = drawCardsFromDeck(
+      deck,
+      1,
+      [],
+      Math.random,
+    );
+    expect(drawnCards).toHaveLength(1);
+    expect(newDeck).toHaveLength(2);
+  });
+  test("山札の最後の1枚を1枚だけ引いた時、1枚引けて、山札が1枚減り、捨札は変わらない", () => {
+    const deck = ["1", "2", "3"];
+    const discardPile = ["4"];
+    const {
+      drawnCards,
+      deck: newDeck,
+      discardPile: newDiscardPile,
+    } = drawCardsFromDeck(deck, 1, discardPile, Math.random);
+    expect(drawnCards).toHaveLength(1);
+    expect(newDeck).toHaveLength(2);
+    expect(newDiscardPile).toStrictEqual(discardPile);
+  });
+  test("山札が残り1枚で2枚引いた時、2枚引けて、捨札は山札に移動して空になり、山札は捨札の-1枚の数になる", () => {
+    const deck = ["1"];
+    const discardPile = ["2", "3", "4", "5"];
+    const {
+      drawnCards,
+      deck: newDeck,
+      discardPile: newDiscardPile,
+    } = drawCardsFromDeck(deck, 2, discardPile, Math.random);
+    expect(drawnCards).toHaveLength(2);
+    expect(newDeck).toHaveLength(3);
+    expect(newDiscardPile).toStrictEqual([]);
+    expect([...drawnCards, ...newDeck].sort()).toStrictEqual([
+      "1",
+      "2",
+      "3",
+      "4",
+      "5",
+    ]);
+  });
+});
+describe("addCardsToHandOrDiscardPile", () => {
+  const testCases: {
+    args: Parameters<typeof addCardsToHandOrDiscardPile>;
+    expected: ReturnType<typeof addCardsToHandOrDiscardPile>;
+  }[] = [
+    {
+      args: [["1", "2", "3", "4", "5"], [], []],
+      expected: {
+        hand: ["1", "2", "3", "4", "5"],
+        discardPile: [],
+      },
+    },
+    {
+      args: [["1", "2", "3", "4", "5", "6", "7"], [], []],
+      expected: {
+        hand: ["1", "2", "3", "4", "5"],
+        discardPile: ["6", "7"],
+      },
+    },
+    {
+      args: [["3", "4", "5"], ["1", "2"], []],
+      expected: {
+        hand: ["1", "2", "3", "4", "5"],
+        discardPile: [],
+      },
+    },
+    {
+      args: [["3", "4", "5", "6", "7"], ["1", "2"], []],
+      expected: {
+        hand: ["1", "2", "3", "4", "5"],
+        discardPile: ["6", "7"],
+      },
+    },
+    {
+      args: [
+        ["8", "9"],
+        ["1", "2", "3", "4", "5"],
+        ["6", "7"],
+      ],
+      expected: {
+        hand: ["1", "2", "3", "4", "5"],
+        discardPile: ["6", "7", "8", "9"],
+      },
+    },
+  ];
+  test.each(testCases)(
+    "Drawn:$args.0, Hand:$args.1, Discard:$args.2 => Hand:$expected.hand, Discard:$expected.discardPile",
+    ({ args, expected }) => {
+      expect(addCardsToHandOrDiscardPile(...args)).toStrictEqual(expected);
+    },
+  );
+});
+describe("createCardPlacementDiff", () => {
+  const testCases: {
+    args: Parameters<typeof createCardPlacementDiff>;
+    expected: ReturnType<typeof createCardPlacementDiff>;
+    name: string;
+  }[] = [
+    {
+      name: "before側だけ存在しても差分は返さない",
+      args: [
+        {
+          deck: ["1"],
+          discardPile: ["2"],
+          hand: ["3"],
+          removedCardPile: ["4"],
+        },
+        {},
+      ],
+      expected: { kind: "cardPlacement" },
+    },
+    {
+      name: "after側だけ存在しても差分は返さない",
+      args: [
+        {},
+        {
+          deck: ["1"],
+          discardPile: ["2"],
+          hand: ["3"],
+          removedCardPile: ["4"],
+        },
+      ],
+      expected: { kind: "cardPlacement" },
+    },
+    {
+      name: "全ての値がbefore/afterで同じ場合は差分を返さない",
+      args: [
+        {
+          deck: ["1"],
+          discardPile: ["2"],
+          hand: ["3"],
+          removedCardPile: ["4"],
+        },
+        {
+          deck: ["1"],
+          discardPile: ["2"],
+          hand: ["3"],
+          removedCardPile: ["4"],
+        },
+      ],
+      expected: { kind: "cardPlacement" },
+    },
+    {
+      name: "deckのみの差分を返せる",
+      args: [
+        {
+          deck: ["1"],
+          discardPile: ["2"],
+          hand: ["3"],
+          removedCardPile: ["4"],
+        },
+        {
+          deck: ["11"],
+          discardPile: ["2"],
+          hand: ["3"],
+          removedCardPile: ["4"],
+        },
+      ],
+      expected: { kind: "cardPlacement", deck: ["11"] },
+    },
+    {
+      name: "discardPileのみの差分を返せる",
+      args: [
+        {
+          deck: ["1"],
+          discardPile: ["2"],
+          hand: ["3"],
+          removedCardPile: ["4"],
+        },
+        {
+          deck: ["1"],
+          discardPile: ["22"],
+          hand: ["3"],
+          removedCardPile: ["4"],
+        },
+      ],
+      expected: { kind: "cardPlacement", discardPile: ["22"] },
+    },
+    {
+      name: "handのみの差分を返せる",
+      args: [
+        {
+          deck: ["1"],
+          discardPile: ["2"],
+          hand: ["3"],
+          removedCardPile: ["4"],
+        },
+        {
+          deck: ["1"],
+          discardPile: ["2"],
+          hand: ["33"],
+          removedCardPile: ["4"],
+        },
+      ],
+      expected: { kind: "cardPlacement", hand: ["33"] },
+    },
+    {
+      name: "removedCardPileのみの差分を返せる",
+      args: [
+        {
+          deck: ["1"],
+          discardPile: ["2"],
+          hand: ["3"],
+          removedCardPile: ["4"],
+        },
+        {
+          deck: ["1"],
+          discardPile: ["2"],
+          hand: ["3"],
+          removedCardPile: ["44"],
+        },
+      ],
+      expected: { kind: "cardPlacement", removedCardPile: ["44"] },
+    },
+  ];
+  test.each(testCases)("$name", ({ args, expected }) => {
+    expect(createCardPlacementDiff(...args)).toStrictEqual(expected);
+  });
+});
+describe("validateCostComsumution", () => {
+  const testCases: Array<{
+    args: Parameters<typeof validateCostComsumution>;
+    expected: ReturnType<typeof validateCostComsumution>;
+    name: string;
+  }> = [
+    {
+      name: "normalコストに対してlifeが足りる時、スキルカードが使える",
+      args: [
+        {
+          life: 3,
+          vitality: 0,
+          modifiers: [] as Idol["modifiers"],
+        } as Idol,
+        { kind: "normal", value: 3 },
+      ],
+      expected: true,
+    },
+    {
+      name: "normalコストに対してvitalityが足りる時、スキルカードが使える",
+      args: [
+        {
+          life: 0,
+          vitality: 3,
+          modifiers: [] as Idol["modifiers"],
+        } as Idol,
+        { kind: "normal", value: 3 },
+      ],
+      expected: true,
+    },
+    {
+      name: "normalコストに対してlifeとvitalityの合計が足りる時、スキルカードが使える",
+      args: [
+        {
+          life: 1,
+          vitality: 2,
+          modifiers: [] as Idol["modifiers"],
+        } as Idol,
+        { kind: "normal", value: 3 },
+      ],
+      expected: true,
+    },
+    {
+      name: "normalコストに対してlifeとvitalityの合計が足りない時、スキルカードが使えない",
+      args: [
+        {
+          life: 1,
+          vitality: 2,
+          modifiers: [] as Idol["modifiers"],
+        } as Idol,
+        { kind: "normal", value: 4 },
+      ],
+      expected: false,
+    },
+    {
+      name: "lifeコストを満たす時、スキルカードが使える",
+      args: [
+        {
+          life: 3,
+          vitality: 0,
+          modifiers: [] as Idol["modifiers"],
+        } as Idol,
+        { kind: "life", value: 3 },
+      ],
+      expected: true,
+    },
+    {
+      name: "lifeコスト満たさない時、スキルカードが使えない",
+      args: [
+        {
+          life: 3,
+          vitality: 10,
+          modifiers: [] as Idol["modifiers"],
+        } as Idol,
+        { kind: "life", value: 4 },
+      ],
+      expected: false,
+    },
+    {
+      name: "focusコストを満たす時、スキルカードが使える",
+      args: [
+        {
+          life: 0,
+          vitality: 0,
+          modifiers: [{ kind: "focus", amount: 3 }] as Idol["modifiers"],
+        } as Idol,
+        { kind: "focus", value: 3 },
+      ],
+      expected: true,
+    },
+    {
+      name: "focusコストを満たさない時、スキルカードが使えない",
+      args: [
+        {
+          life: 0,
+          vitality: 0,
+          modifiers: [{ kind: "focus", amount: 3 }] as Idol["modifiers"],
+        } as Idol,
+        { kind: "focus", value: 4 },
+      ],
+      expected: false,
+    },
+    {
+      name: "goodConditionコストを満たす時、スキルカードが使える",
+      args: [
+        {
+          life: 0,
+          vitality: 0,
+          modifiers: [
+            { kind: "goodCondition", duration: 3 },
+          ] as Idol["modifiers"],
+        } as Idol,
+        { kind: "goodCondition", value: 3 },
+      ],
+      expected: true,
+    },
+    {
+      name: "goodConditionコストを満たさない時、スキルカードが使えない",
+      args: [
+        {
+          life: 0,
+          vitality: 0,
+          modifiers: [
+            { kind: "goodCondition", duration: 3 },
+          ] as Idol["modifiers"],
+        } as Idol,
+        { kind: "goodCondition", value: 4 },
+      ],
+      expected: false,
+    },
+    {
+      name: "motivationコストを満たす時、スキルカードが使える",
+      args: [
+        {
+          life: 0,
+          vitality: 0,
+          modifiers: [{ kind: "motivation", amount: 3 }] as Idol["modifiers"],
+        } as Idol,
+        { kind: "motivation", value: 3 },
+      ],
+      expected: true,
+    },
+    {
+      name: "motivationコストを満たさない時、スキルカードが使えない",
+      args: [
+        {
+          life: 0,
+          vitality: 0,
+          modifiers: [{ kind: "motivation", amount: 3 }] as Idol["modifiers"],
+        } as Idol,
+        { kind: "motivation", value: 4 },
+      ],
+      expected: false,
+    },
+    {
+      name: "positiveImpressionコストを満たす時、スキルカードが使える",
+      args: [
+        {
+          life: 0,
+          vitality: 0,
+          modifiers: [
+            { kind: "positiveImpression", amount: 3 },
+          ] as Idol["modifiers"],
+        } as Idol,
+        { kind: "positiveImpression", value: 3 },
+      ],
+      expected: true,
+    },
+    {
+      name: "positiveImpressionコストを満たさない時、スキルカードが使えない",
+      args: [
+        {
+          life: 0,
+          vitality: 0,
+          modifiers: [
+            { kind: "positiveImpression", amount: 3 },
+          ] as Idol["modifiers"],
+        } as Idol,
+        { kind: "positiveImpression", value: 4 },
+      ],
+      expected: false,
+    },
+  ];
+  test.each(testCases)("$name", ({ args, expected }) => {
+    expect(validateCostComsumution(...args)).toStrictEqual(expected);
+  });
+});
+// validateCostComsumution で検証できる内容はそちらで行う
+describe("canUseCard", () => {
+  const testCases: Array<{
+    args: Parameters<typeof canUseCard>;
+    expected: ReturnType<typeof canUseCard>;
+    name: string;
+  }> = [
+    {
+      name: "コストを満たすリソースがない時、スキルカードを使えない",
+      args: [
+        {
+          idol: {
+            life: 3,
+            vitality: 0,
+            modifiers: [] as Idol["modifiers"],
+          },
+        } as Lesson,
+        { kind: "normal", value: 4 },
+        undefined,
+      ],
+      expected: false,
+    },
+    {
+      name: "コストを満たすリソースがあり、追加条件が無い時、スキルカードを使える",
+      args: [
+        {
+          idol: {
+            life: 3,
+            vitality: 0,
+            modifiers: [] as Idol["modifiers"],
+          },
+        } as Lesson,
+        { kind: "normal", value: 3 },
+        undefined,
+      ],
+      expected: true,
+    },
+    {
+      name: "ターン数の追加条件を満たす時、スキルカードを使える",
+      args: [
+        {
+          idol: {
+            life: 0,
+            vitality: 0,
+            modifiers: [] as Idol["modifiers"],
+          },
+          turnNumber: 3,
+        } as Lesson,
+        { kind: "normal", value: 0 },
+        { kind: "countTurnNumber", min: 3 },
+      ],
+      expected: true,
+    },
+    {
+      name: "ターン数の追加条件を満たさない時、スキルカードを使えない",
+      args: [
+        {
+          idol: {
+            life: 0,
+            vitality: 0,
+            modifiers: [] as Idol["modifiers"],
+          },
+          turnNumber: 2,
+        } as Lesson,
+        { kind: "normal", value: 0 },
+        { kind: "countTurnNumber", min: 3 },
+      ],
+      expected: false,
+    },
+    {
+      name: "元気0の追加条件を満たす時、スキルカードを使える",
+      args: [
+        {
+          idol: {
+            life: 0,
+            vitality: 0,
+            modifiers: [] as Idol["modifiers"],
+          },
+          turnNumber: 3,
+        } as Lesson,
+        { kind: "normal", value: 0 },
+        { kind: "countVitalityZero" },
+      ],
+      expected: true,
+    },
+    {
+      name: "元気0の追加条件を満たさない時、スキルカードを使えない",
+      args: [
+        {
+          idol: {
+            life: 0,
+            vitality: 1,
+            modifiers: [] as Idol["modifiers"],
+          },
+          turnNumber: 3,
+        } as Lesson,
+        { kind: "normal", value: 0 },
+        { kind: "countVitalityZero" },
+      ],
+      expected: false,
+    },
+    {
+      name: "好調所持の追加条件を満たす時、スキルカードを使える",
+      args: [
+        {
+          idol: {
+            life: 3,
+            vitality: 0,
+            modifiers: [
+              { kind: "goodCondition", duration: 1 },
+            ] as Idol["modifiers"],
+          },
+          turnNumber: 3,
+        } as Lesson,
+        { kind: "normal", value: 3 },
+        { kind: "hasGoodCondition" },
+      ],
+      expected: true,
+    },
+    {
+      name: "好調所持の追加条件を満たさない時、スキルカードを使える",
+      args: [
+        {
+          idol: {
+            life: 3,
+            vitality: 0,
+            modifiers: [] as Idol["modifiers"],
+          },
+          turnNumber: 3,
+        } as Lesson,
+        { kind: "normal", value: 3 },
+        { kind: "hasGoodCondition" },
+      ],
+      expected: false,
+    },
+    {
+      name: "life比率以上の追加条件を満たす時、スキルカードを使える",
+      args: [
+        {
+          idol: {
+            life: 5,
+            original: {
+              maxLife: 10,
+            },
+            vitality: 0,
+            modifiers: [] as Idol["modifiers"],
+          },
+        } as Lesson,
+        { kind: "normal", value: 3 },
+        {
+          kind: "measureValue",
+          valueKind: "life",
+          criterionKind: "greaterEqual",
+          percentage: 50,
+        },
+      ],
+      expected: true,
+    },
+    {
+      name: "life比率以上の追加条件を満たさない時、スキルカードを使えない",
+      args: [
+        {
+          idol: {
+            life: 4,
+            original: {
+              maxLife: 10,
+            },
+            vitality: 0,
+            modifiers: [] as Idol["modifiers"],
+          },
+        } as Lesson,
+        { kind: "normal", value: 3 },
+        {
+          kind: "measureValue",
+          valueKind: "life",
+          criterionKind: "greaterEqual",
+          percentage: 50,
+        },
+      ],
+      expected: false,
+    },
+    {
+      name: "life比率以下の追加条件を満たす時、スキルカードを使える",
+      args: [
+        {
+          idol: {
+            life: 5,
+            original: {
+              maxLife: 10,
+            },
+            vitality: 0,
+            modifiers: [] as Idol["modifiers"],
+          },
+        } as Lesson,
+        { kind: "normal", value: 3 },
+        {
+          kind: "measureValue",
+          valueKind: "life",
+          criterionKind: "lessEqual",
+          percentage: 50,
+        },
+      ],
+      expected: true,
+    },
+    {
+      name: "life比率以下の追加条件を満たさない時、スキルカードを使えない",
+      args: [
+        {
+          idol: {
+            life: 6,
+            original: {
+              maxLife: 10,
+            },
+            vitality: 0,
+            modifiers: [] as Idol["modifiers"],
+          },
+        } as Lesson,
+        { kind: "normal", value: 3 },
+        {
+          kind: "measureValue",
+          valueKind: "life",
+          criterionKind: "lessEqual",
+          percentage: 50,
+        },
+      ],
+      expected: false,
+    },
+    {
+      name: "score比率以上の追加条件を満たす時、スキルカードを使える",
+      args: [
+        {
+          idol: {
+            life: 0,
+            vitality: 0,
+            modifiers: [] as Idol["modifiers"],
+          },
+          score: 10,
+          clearScoreThresholds: {
+            clear: 10,
+          },
+        } as Lesson,
+        { kind: "normal", value: 0 },
+        {
+          kind: "measureValue",
+          valueKind: "score",
+          criterionKind: "greaterEqual",
+          percentage: 100,
+        },
+      ],
+      expected: true,
+    },
+    {
+      name: "score比率以上の追加条件を満たさない時、スキルカードを使えない",
+      args: [
+        {
+          idol: {
+            life: 0,
+            vitality: 0,
+            modifiers: [] as Idol["modifiers"],
+          },
+          score: 9,
+          clearScoreThresholds: {
+            clear: 10,
+          },
+        } as Lesson,
+        { kind: "normal", value: 0 },
+        {
+          kind: "measureValue",
+          valueKind: "score",
+          criterionKind: "greaterEqual",
+          percentage: 100,
+        },
+      ],
+      expected: false,
+    },
+    {
+      name: "score比率以下の追加条件を満たす時、スキルカードを使える",
+      args: [
+        {
+          idol: {
+            life: 0,
+            vitality: 0,
+            modifiers: [] as Idol["modifiers"],
+          },
+          score: 10,
+          clearScoreThresholds: {
+            clear: 10,
+          },
+        } as Lesson,
+        { kind: "normal", value: 0 },
+        {
+          kind: "measureValue",
+          valueKind: "score",
+          criterionKind: "lessEqual",
+          percentage: 100,
+        },
+      ],
+      expected: true,
+    },
+    {
+      name: "score比率以下の追加条件を満たさない時、スキルカードを使えない",
+      args: [
+        {
+          idol: {
+            life: 0,
+            vitality: 0,
+            modifiers: [] as Idol["modifiers"],
+          },
+          score: 11,
+          clearScoreThresholds: {
+            clear: 10,
+          },
+        } as Lesson,
+        { kind: "normal", value: 0 },
+        {
+          kind: "measureValue",
+          valueKind: "score",
+          criterionKind: "lessEqual",
+          percentage: 100,
+        },
+      ],
+      expected: false,
+    },
+    {
+      name: "score比率の追加条件があるが、レッスンにクリアスコア閾値が設定されていない時、スキルカードを使える",
+      args: [
+        {
+          idol: {
+            life: 0,
+            vitality: 0,
+            modifiers: [] as Idol["modifiers"],
+          },
+          score: 10,
+        } as Lesson,
+        { kind: "normal", value: 0 },
+        {
+          kind: "measureValue",
+          valueKind: "score",
+          criterionKind: "greaterEqual",
+          percentage: 100,
+        },
+      ],
+      expected: true,
+    },
+  ];
+  test.each(testCases)("$name", ({ args, expected }) => {
+    expect(canUseCard(...args)).toStrictEqual(expected);
+  });
+});
+describe("canApplyEffect", () => {
+  const testCases: Array<{
+    args: Parameters<typeof canApplyEffect>;
+    expected: ReturnType<typeof canApplyEffect>;
+    name: string;
+  }> = [
+    {
+      name: "countModifierのfocusを満たす時、trueを返す",
+      args: [
+        {
+          idol: {
+            modifiers: [{ kind: "focus", amount: 3 }] as Idol["modifiers"],
+          },
+        } as Lesson,
+        { kind: "countModifier", modifierKind: "focus", min: 3 },
+      ],
+      expected: true,
+    },
+    {
+      name: "countModifierのfocusを満たさない時、falseを返す",
+      args: [
+        {
+          idol: {
+            modifiers: [{ kind: "focus", amount: 2 }] as Idol["modifiers"],
+          },
+        } as Lesson,
+        { kind: "countModifier", modifierKind: "focus", min: 3 },
+      ],
+      expected: false,
+    },
+    {
+      name: "countModifierのmotivationを満たす時、trueを返す",
+      args: [
+        {
+          idol: {
+            modifiers: [{ kind: "motivation", amount: 3 }] as Idol["modifiers"],
+          },
+        } as Lesson,
+        { kind: "countModifier", modifierKind: "motivation", min: 3 },
+      ],
+      expected: true,
+    },
+    {
+      name: "countModifierのmotivationを満たさない時、falseを返す",
+      args: [
+        {
+          idol: {
+            modifiers: [{ kind: "motivation", amount: 2 }] as Idol["modifiers"],
+          },
+        } as Lesson,
+        { kind: "countModifier", modifierKind: "motivation", min: 3 },
+      ],
+      expected: false,
+    },
+    {
+      name: "countModifierのpositiveImpressionを満たす時、trueを返す",
+      args: [
+        {
+          idol: {
+            modifiers: [
+              { kind: "positiveImpression", amount: 3 },
+            ] as Idol["modifiers"],
+          },
+        } as Lesson,
+        { kind: "countModifier", modifierKind: "positiveImpression", min: 3 },
+      ],
+      expected: true,
+    },
+    {
+      name: "countModifierのpositiveImpressionを満たさない時、falseを返す",
+      args: [
+        {
+          idol: {
+            modifiers: [
+              { kind: "positiveImpression", amount: 2 },
+            ] as Idol["modifiers"],
+          },
+        } as Lesson,
+        { kind: "countModifier", modifierKind: "positiveImpression", min: 3 },
+      ],
+      expected: false,
+    },
+    {
+      name: "countReminingTurnsを満たす時、trueを返す",
+      args: [
+        {
+          turnNumber: 4,
+          lastTurnNumber: 6,
+          remainingTurns: 0,
+        } as Lesson,
+        { kind: "countReminingTurns", max: 3 },
+      ],
+      expected: true,
+    },
+    {
+      name: "countReminingTurnsを満たさない時、falseを返す",
+      args: [
+        {
+          turnNumber: 4,
+          lastTurnNumber: 6,
+          remainingTurns: 0,
+        } as Lesson,
+        { kind: "countReminingTurns", max: 2 },
+      ],
+      expected: false,
+    },
+    {
+      name: "countVitalityを満たす時、trueを返す",
+      args: [
+        {
+          idol: {
+            vitality: 1,
+          },
+        } as Lesson,
+        { kind: "countVitality", range: { min: 1, max: 1 } },
+      ],
+      expected: true,
+    },
+    {
+      name: "countVitalityを満たさない時、falseを返す",
+      args: [
+        {
+          idol: {
+            vitality: 1,
+          },
+        } as Lesson,
+        { kind: "countVitality", range: { min: 2, max: 2 } },
+      ],
+      expected: false,
+    },
+    {
+      name: "hasGoodConditionを満たす時、trueを返す",
+      args: [
+        {
+          idol: {
+            modifiers: [
+              { kind: "goodCondition", duration: 1 },
+            ] as Idol["modifiers"],
+          },
+        } as Lesson,
+        { kind: "hasGoodCondition" },
+      ],
+      expected: true,
+    },
+    {
+      name: "hasGoodConditionを満たさない時、falseを返す",
+      args: [
+        {
+          idol: {
+            modifiers: [{ kind: "focus", amount: 1 }] as Idol["modifiers"],
+          },
+        } as Lesson,
+        { kind: "hasGoodCondition" },
+      ],
+      expected: false,
+    },
+    {
+      name: "measureIfLifeIsEqualGreaterThanHalfを満たす時、trueを返す",
+      args: [
+        {
+          idol: {
+            life: 5,
+            original: {
+              maxLife: 10,
+            },
+          },
+        } as Lesson,
+        { kind: "measureIfLifeIsEqualGreaterThanHalf" },
+      ],
+      expected: true,
+    },
+    {
+      name: "measureIfLifeIsEqualGreaterThanHalfを満たさない時、falseを返す",
+      args: [
+        {
+          idol: {
+            life: 4,
+            original: {
+              maxLife: 10,
+            },
+          },
+        } as Lesson,
+        { kind: "measureIfLifeIsEqualGreaterThanHalf" },
+      ],
+      expected: false,
+    },
+  ];
+  test.each(testCases)("$name", ({ args, expected }) => {
+    expect(canApplyEffect(...args)).toBe(expected);
+  });
+});
+describe("drawCardsOnLessonStart", () => {
+  test("山札に引く数が残っている時、山札はその分減り、捨札に変化はない", () => {
+    const lessonMock = {
+      hand: [] as Lesson["hand"],
+      deck: ["1", "2", "3"],
+      discardPile: ["4"],
+    } as Lesson;
+    const updates = drawCardsOnLessonStart(lessonMock, {
+      count: 3,
+      historyResultIndex: 1,
+      getRandom: Math.random,
+    });
+    const update = updates.find((e) => e.kind === "cardPlacement") as any;
+    expect(update.hand).toHaveLength(3);
+    expect(update.deck).toHaveLength(0);
+    expect(update.discardPile).toBeUndefined();
+    expect(update.removedCardPile).toBeUndefined();
+  });
+  test("山札に引く数が残っていない時、山札は再構築された上で残りの引く数分減り、捨札は空になる", () => {
+    const lessonMock = {
+      hand: [] as Lesson["hand"],
+      deck: ["1", "2"],
+      discardPile: ["3", "4"],
+    } as Lesson;
+    const updates = drawCardsOnLessonStart(lessonMock, {
+      count: 3,
+      historyResultIndex: 1,
+      getRandom: Math.random,
+    });
+    const update = updates.find((e) => e.kind === "cardPlacement") as any;
+    expect(update.hand).toHaveLength(3);
+    expect(update.deck).toHaveLength(1);
+    expect(update.discardPile).toHaveLength(0);
+    expect(update.removedCardPile).toBeUndefined();
+  });
+  test("手札最大数を超える枚数を引いた時、入らないスキルカードは捨札へ移動する", () => {
+    const lessonMock = {
+      hand: [] as Lesson["hand"],
+      deck: ["1", "2", "3", "4", "5", "6"],
+      discardPile: [] as Lesson["discardPile"],
+    } as Lesson;
+    const updates = drawCardsOnLessonStart(lessonMock, {
+      count: 6,
+      historyResultIndex: 1,
+      getRandom: Math.random,
+    });
+    const update = updates.find((e) => e.kind === "cardPlacement") as any;
+    expect(update.hand).toHaveLength(5);
+    expect(update.deck).toHaveLength(0);
+    expect(update.discardPile).toHaveLength(1);
+    expect(update.removedCardPile).toBeUndefined();
+  });
+});
+describe("calculatePerformingScoreEffect", () => {
+  const testCases: {
+    args: Parameters<typeof calculatePerformingScoreEffect>;
+    expected: ReturnType<typeof calculatePerformingScoreEffect>;
+    name: string;
+  }[] = [
+    {
+      name: "状態変化などの条件がない時、指定通りのスコアを返す",
+      args: [
+        {
+          modifiers: [] as Idol["modifiers"],
+        } as Idol,
+        undefined,
+        { value: 9 },
+      ],
+      expected: [{ kind: "score", actual: 9, max: 9 }],
+    },
+    {
+      name: "アイドルへ好調のみが付与されている時、1.5倍（端数切り上げ）したスコアを返す",
+      args: [
+        {
+          modifiers: [{ kind: "goodCondition", duration: 1 }],
+        } as Idol,
+        undefined,
+        { value: 9 },
+      ],
+      expected: [{ kind: "score", actual: 14, max: 14 }],
+    },
+    {
+      name: "アイドルへ集中のみが付与されている時、その分を加算したスコアを返す",
+      args: [
+        {
+          modifiers: [{ kind: "focus", amount: 1 }],
+        } as Idol,
+        undefined,
+        { value: 9 },
+      ],
+      expected: [{ kind: "score", actual: 10, max: 10 }],
+    },
+    {
+      name: "アイドルへパラメータ上昇量増加50%のみが付与されている時、1.5倍（端数切り上げ）したスコアを返す",
+      args: [
+        {
+          modifiers: [{ kind: "mightyPerformance", duration: 1 }],
+        } as Idol,
+        undefined,
+        { value: 9 },
+      ],
+      expected: [{ kind: "score", actual: 14, max: 14 }],
+    },
+    {
+      name: "アイドルへ好調と集中が付与されている時、集中分も好調の倍率の影響を受ける",
+      args: [
+        {
+          modifiers: [
+            { kind: "goodCondition", duration: 1 },
+            { kind: "focus", amount: 3 },
+          ],
+        } as Idol,
+        undefined,
+        { value: 1 },
+      ],
+      expected: [{ kind: "score", actual: 6, max: 6 }],
+    },
+    {
+      name: "アイドルへ好調と絶好調が付与されている時、(1.5 + 好調ターン数 * 0.1)倍したスコアを返す",
+      args: [
+        {
+          modifiers: [
+            { kind: "goodCondition", duration: 5 },
+            { kind: "excellentCondition", duration: 1 },
+          ],
+        } as Idol,
+        undefined,
+        { value: 10 },
+      ],
+      expected: [{ kind: "score", actual: 20, max: 20 }],
+    },
+    {
+      name: "アイドルへ絶好調のみが付与されている時、好調の効果は発動しない",
+      args: [
+        {
+          modifiers: [{ kind: "excellentCondition", duration: 1 }],
+        } as Idol,
+        undefined,
+        { value: 10 },
+      ],
+      expected: [{ kind: "score", actual: 10, max: 10 }],
+    },
+    {
+      name: "アイドルへ好調とパラメータ上昇量増加50%が付与されている時、(1.5 * 1.5)倍のスコアを返す",
+      args: [
+        {
+          modifiers: [
+            { kind: "goodCondition", duration: 1 },
+            { kind: "mightyPerformance", duration: 1 },
+          ],
+        } as Idol,
+        undefined,
+        { value: 10 },
+      ],
+      expected: [{ kind: "score", actual: 23, max: 23 }],
+    },
+    {
+      name: "スコアのクエリに集中増幅効果が指定されている時、集中の効果をその倍率分増加する",
+      args: [
+        {
+          modifiers: [{ kind: "focus", amount: 1 }],
+        } as Idol,
+        undefined,
+        { value: 1, focusMultiplier: 2.0 },
+      ],
+      expected: [{ kind: "score", actual: 3, max: 3 }],
+    },
+    {
+      name: "スコアのクエリに回数が指定されている時、状態修正や集中増幅効果などの影響を反映した結果を回数分の結果で返す",
+      args: [
+        {
+          modifiers: [{ kind: "focus", amount: 1 }],
+        } as Idol,
+        undefined,
+        { value: 1, focusMultiplier: 2.0, times: 2 },
+      ],
+      expected: [
+        { kind: "score", actual: 3, max: 3 },
+        { kind: "score", actual: 3, max: 3 },
+      ],
+    },
+    {
+      name: "スコア増加値の上限が設定されている時、actualはその値を超えない",
+      args: [
+        {
+          modifiers: [] as Idol["modifiers"],
+        } as Idol,
+        6,
+        { value: 10 },
+      ],
+      expected: [{ kind: "score", actual: 6, max: 10 }],
+    },
+    {
+      name: "スコア増加値の上限が設定されている中で複数回スコア増加の時、スコア増加の累計と上限を比較する",
+      args: [
+        {
+          modifiers: [] as Idol["modifiers"],
+        } as Idol,
+        16,
+        { value: 10, times: 3 },
+      ],
+      expected: [
+        { kind: "score", actual: 10, max: 10 },
+        { kind: "score", actual: 6, max: 10 },
+        { kind: "score", actual: 0, max: 10 },
+      ],
+    },
+    {
+      name: "集中:4,好調:6,絶好調:有,ハイタッチ{未強化,+17,集中*1.5} は `(17 + 4 * 1.5) * (1.5 + 0.6) = 48.30` で 49 を返す",
+      args: [
+        {
+          modifiers: [
+            { kind: "focus", amount: 4 },
+            { kind: "goodCondition", duration: 6 },
+            { kind: "excellentCondition", duration: 1 },
+          ] as Idol["modifiers"],
+        } as Idol,
+        undefined,
+        { value: 17, focusMultiplier: 1.5 },
+      ],
+      expected: [{ kind: "score", actual: 49, max: 49 }],
+    },
+  ];
+  test.each(testCases)("$name", ({ args, expected }) => {
+    expect(calculatePerformingScoreEffect(...args)).toStrictEqual(expected);
+  });
+});
+describe("calculatePerformingVitalityEffect", () => {
+  const testCases: {
+    args: Parameters<typeof calculatePerformingVitalityEffect>;
+    expected: ReturnType<typeof calculatePerformingVitalityEffect>;
+    name: string;
+  }[] = [
+    {
+      name: "通常の元気増加",
+      args: [
+        {
+          vitality: 0,
+          modifiers: [] as Idol["modifiers"],
+        } as Idol,
+        { value: 1 },
+      ],
+      expected: {
+        kind: "vitality",
+        actual: 1,
+        max: 1,
+      },
+    },
+    {
+      name: "やる気の数値を元気増加時に加算する",
+      args: [
+        {
+          vitality: 0,
+          modifiers: [{ kind: "motivation", amount: 10 }] as Idol["modifiers"],
+        } as Idol,
+        { value: 1 },
+      ],
+      expected: {
+        kind: "vitality",
+        actual: 11,
+        max: 11,
+      },
+    },
+    {
+      name: "「レッスン中に使用したスキルカード1枚ごとに、元気増加量+n」の効果",
+      args: [
+        {
+          vitality: 0,
+          modifiers: [] as Idol["modifiers"],
+          totalCardUsageCount: 3,
+        } as Idol,
+        { value: 1, boostPerCardUsed: 2 },
+      ],
+      expected: {
+        kind: "vitality",
+        actual: 7,
+        max: 7,
+      },
+    },
+    {
+      name: "固定元気の時、他のいかなる修正も無視する",
+      args: [
+        {
+          vitality: 0,
+          modifiers: [{ kind: "motivation", amount: 10 }] as Idol["modifiers"],
+          totalCardUsageCount: 3,
+        } as Idol,
+        { value: 1, boostPerCardUsed: 2, fixedValue: true },
+      ],
+      expected: {
+        kind: "vitality",
+        actual: 1,
+        max: 1,
+      },
+    },
+  ];
+  test.each(testCases)("$name", ({ args, expected }) => {
+    expect(calculatePerformingVitalityEffect(...args)).toStrictEqual(expected);
+  });
+});
+describe("useCard", () => {
+  const createLessonForTest = (
+    overwrites: Partial<Parameters<typeof createIdolInProduction>[0]> = {},
+  ): Lesson => {
+    const idolInProduction = createIdolInProduction({
+      // Pアイテムが最終ターンにならないと発動しないので、テストデータとして優秀
+      idolDefinitionId: "shinosawahiro-r-1",
+      cards: [],
+      specificCardEnhanced: false,
+      specificProducerItemEnhanced: false,
+      idGenerator: createIdGenerator(),
+      ...overwrites,
+    });
+    return createLesson({
+      clearScoreThresholds: undefined,
+      getRandom: Math.random,
+      idolInProduction,
+      lastTurnNumber: 6,
+    });
+  };
+  describe("使用した手札を捨札か除外へ移動", () => {
+    test("「レッスン中1回」ではない手札を使った時は、捨札へ移動", () => {
+      const lesson = createLessonForTest({
+        cards: [
+          {
+            id: "a",
+            definition: getCardDataById("apirunokihon"),
+            enabled: true,
+            enhanced: false,
+          },
+        ],
+      });
+      lesson.hand = ["a"];
+      const { updates } = useCard(lesson, 1, {
+        selectedCardInHandIndex: 0,
+        getRandom: () => 0,
+        idGenerator: createIdGenerator(),
+      });
+      const update = updates.find((e) => e.kind === "cardPlacement") as any;
+      expect(update.hand).toStrictEqual([]);
+      expect(update.deck).toBeUndefined();
+      expect(update.discardPile).toStrictEqual(["a"]);
+      expect(update.removedCardPile).toBeUndefined();
+    });
+    test("「レッスン中1回」の手札を使った時は、除外へ移動", () => {
+      const lesson = createLessonForTest({
+        cards: [
+          {
+            id: "a",
+            definition: getCardDataById("hyogennokihon"),
+            enabled: true,
+            enhanced: false,
+          },
+        ],
+      });
+      lesson.hand = ["a"];
+      const { updates } = useCard(lesson, 1, {
+        selectedCardInHandIndex: 0,
+        getRandom: () => 0,
+        idGenerator: createIdGenerator(),
+      });
+      const update = updates.find((e) => e.kind === "cardPlacement") as any;
+      expect(update.hand).toStrictEqual([]);
+      expect(update.deck).toBeUndefined();
+      expect(update.discardPile).toBeUndefined();
+      expect(update.removedCardPile).toStrictEqual(["a"]);
+    });
+  });
+  describe("コスト消費", () => {
+    test("全て元気で賄った時のnormal", () => {
+      const lesson = createLessonForTest({
+        cards: [
+          {
+            id: "a",
+            definition: getCardDataById("apirunokihon"),
+            enabled: true,
+            enhanced: false,
+          },
+        ],
+      });
+      lesson.hand = ["a"];
+      lesson.idol.vitality = 4;
+      const { updates } = useCard(lesson, 1, {
+        selectedCardInHandIndex: 0,
+        getRandom: () => 0,
+        idGenerator: createIdGenerator(),
+      });
+      expect(updates.find((e) => e.kind === "vitality")).toStrictEqual({
+        kind: "vitality",
+        actual: -4,
+        max: -4,
+        reason: expect.any(Object),
+      });
+      expect(updates.find((e) => e.kind === "life")).toBeUndefined();
+    });
+    test("一部を元気で賄った時のnormal", () => {
+      const lesson = createLessonForTest({
+        cards: [
+          {
+            id: "a",
+            definition: getCardDataById("apirunokihon"),
+            enabled: true,
+            enhanced: false,
+          },
+        ],
+      });
+      lesson.hand = ["a"];
+      lesson.idol.vitality = 3;
+      const { updates } = useCard(lesson, 1, {
+        selectedCardInHandIndex: 0,
+        getRandom: () => 0,
+        idGenerator: createIdGenerator(),
+      });
+      expect(updates.find((e) => e.kind === "vitality")).toStrictEqual({
+        kind: "vitality",
+        actual: -3,
+        max: -4,
+        reason: expect.any(Object),
+      });
+      expect(updates.find((e) => e.kind === "life")).toStrictEqual({
+        kind: "life",
+        actual: -1,
+        max: -1,
+        reason: expect.any(Object),
+      });
+    });
+    test("life", () => {
+      const lesson = createLessonForTest({
+        cards: [
+          {
+            id: "a",
+            definition: getCardDataById("genkinaaisatsu"),
+            enabled: true,
+            enhanced: false,
+          },
+        ],
+      });
+      lesson.hand = ["a"];
+      const { updates } = useCard(lesson, 1, {
+        selectedCardInHandIndex: 0,
+        getRandom: () => 0,
+        idGenerator: createIdGenerator(),
+      });
+      expect(updates.find((e) => e.kind === "life")).toStrictEqual({
+        kind: "life",
+        actual: -4,
+        max: -4,
+        reason: expect.any(Object),
+      });
+    });
+    test("プロパティにamountがあるmodifier", () => {
+      const lesson = createLessonForTest({
+        cards: [
+          {
+            id: "a",
+            definition: getCardDataById("minnadaisuki"),
+            enabled: true,
+            enhanced: false,
+          },
+        ],
+      });
+      lesson.hand = ["a"];
+      lesson.idol.modifiers = [{ kind: "motivation", amount: 3 }];
+      const { updates } = useCard(lesson, 1, {
+        selectedCardInHandIndex: 0,
+        getRandom: () => 0,
+        idGenerator: createIdGenerator(),
+      });
+      expect(updates.find((e) => e.kind === "modifier")).toStrictEqual({
+        kind: "modifier",
+        modifier: {
+          kind: "motivation",
+          amount: 3,
+        },
+        reason: expect.any(Object),
+      });
+    });
+    test("プロパティにdurationがあるmodifier", () => {
+      const lesson = createLessonForTest({
+        cards: [
+          {
+            id: "a",
+            definition: getCardDataById("sonzaikan"),
+            enabled: true,
+            enhanced: false,
+          },
+        ],
+      });
+      lesson.hand = ["a"];
+      lesson.idol.modifiers = [{ kind: "goodCondition", duration: 2 }];
+      const { updates } = useCard(lesson, 1, {
+        selectedCardInHandIndex: 0,
+        getRandom: () => 0,
+        idGenerator: createIdGenerator(),
+      });
+      expect(updates.find((e) => e.kind === "modifier")).toStrictEqual({
+        kind: "modifier",
+        modifier: {
+          kind: "goodCondition",
+          duration: 2,
+        },
+        reason: expect.any(Object),
+      });
+    });
+    test("状態修正により消費体力が変動", () => {
+      const lesson = createLessonForTest({
+        cards: [
+          {
+            id: "a",
+            definition: getCardDataById("genkinaaisatsu"),
+            enabled: true,
+            enhanced: false,
+          },
+        ],
+      });
+      lesson.hand = ["a"];
+      lesson.idol.modifiers = [{ kind: "lifeConsumptionReduction", value: 1 }];
+      const { updates } = useCard(lesson, 1, {
+        selectedCardInHandIndex: 0,
+        getRandom: () => 0,
+        idGenerator: createIdGenerator(),
+      });
+      expect(updates.find((e) => e.kind === "life")).toStrictEqual({
+        kind: "life",
+        actual: -3,
+        max: -3,
+        reason: expect.any(Object),
+      });
+    });
+  });
+  describe("効果発動・効果適用", () => {
+    describe("効果適用条件を満たさない効果は適用されない", () => {
+      test("「飛躍」は、集中が足りない時、パラメータ上昇は1回のみ適用する", () => {
+        const lesson = createLessonForTest({
+          cards: [
+            {
+              id: "a",
+              definition: getCardDataById("hiyaku"),
+              enabled: true,
+              enhanced: false,
+            },
+          ],
+        });
+        lesson.hand = ["a"];
+        const { updates } = useCard(lesson, 1, {
+          selectedCardInHandIndex: 0,
+          getRandom: () => 0,
+          idGenerator: createIdGenerator(),
+        });
+        expect(updates.filter((e) => e.kind === "score")).toHaveLength(1);
+      });
+    });
+    describe("「次に使用するスキルカードの効果をもう1回発動」が付与されている時", () => {
+      test("コスト消費は1回のみだが、選択したスキルカードの効果を2回発動し、2回目の効果には1回目の状態修正が反映されていて、追加でdoubleEffectを消費する更新を生成する", () => {
+        const lesson = createLessonForTest({
+          cards: [
+            {
+              id: "a",
+              definition: getCardDataById("jumbiundo"),
+              enabled: true,
+              enhanced: false,
+            },
+          ],
+        });
+        lesson.hand = ["a"];
+        lesson.idol.modifiers = [{ kind: "doubleEffect", times: 1 }];
+        const { updates } = useCard(lesson, 1, {
+          selectedCardInHandIndex: 0,
+          getRandom: () => 0,
+          idGenerator: createIdGenerator(),
+        });
+        expect(updates.filter((e) => e.kind === "life")).toHaveLength(1);
+        expect(updates.filter((e) => e.kind === "score")).toHaveLength(2);
+        expect(
+          updates.filter(
+            (e) => e.kind === "modifier" && e.modifier.kind === "focus",
+          ),
+        ).toHaveLength(2);
+        expect(updates.filter((e) => e.kind === "score")[0]).toStrictEqual({
+          kind: "score",
+          actual: 6,
+          max: 6,
+          reason: expect.any(Object),
+        });
+        expect(updates.filter((e) => e.kind === "score")[1]).toStrictEqual({
+          kind: "score",
+          actual: 8,
+          max: 8,
+          reason: expect.any(Object),
+        });
+        expect(
+          updates.filter(
+            (e) => e.kind === "modifier" && e.modifier.kind === "doubleEffect",
+          ),
+        ).toHaveLength(1);
+      });
+    });
+    describe("drawCards", () => {
+      test("「アイドル宣言」を、山札が足りる・手札最大枚数を超えない状況で使った時、手札が2枚増え、捨札は不変で、除外が1枚増える", () => {
+        const lesson = createLessonForTest({
+          cards: [
+            {
+              id: "a",
+              definition: getCardDataById("aidorusengen"),
+              enabled: true,
+              enhanced: false,
+            },
+            ...["b", "c"].map((id) => ({
+              id,
+              definition: getCardDataById("apirunokihon"),
+              enabled: true,
+              enhanced: false,
+            })),
+          ],
+        });
+        lesson.hand = ["a"];
+        lesson.deck = ["b", "c"];
+        const { updates } = useCard(lesson, 1, {
+          selectedCardInHandIndex: 0,
+          getRandom: () => 0,
+          idGenerator: createIdGenerator(),
+        });
+        // 手札使用時の更新があるため、効果による手札増加は2番目の更新になる
+        const update = updates.filter(
+          (e) => e.kind === "cardPlacement",
+        )[1] as any;
+        expect(update.hand).toHaveLength(2);
+        expect(update.deck).toHaveLength(0);
+        expect(update.discardPile).toBeUndefined();
+        expect(update.removedCardPile).toBeUndefined();
+      });
+      test("「アイドル宣言」を、山札が足りない状況で使った時、山札と捨札は再構築される", () => {
+        const lesson = createLessonForTest({
+          cards: [
+            {
+              id: "a",
+              definition: getCardDataById("aidorusengen"),
+              enabled: true,
+              enhanced: false,
+            },
+            ...["b", "c", "d"].map((id) => ({
+              id,
+              definition: getCardDataById("apirunokihon"),
+              enabled: true,
+              enhanced: false,
+            })),
+          ],
+        });
+        lesson.hand = ["a"];
+        lesson.deck = ["b"];
+        lesson.discardPile = ["c", "d"];
+        const { updates } = useCard(lesson, 1, {
+          selectedCardInHandIndex: 0,
+          getRandom: () => 0,
+          idGenerator: createIdGenerator(),
+        });
+        // 手札使用時の更新があるため、効果による手札増加は2番目の更新になる
+        const update = updates.filter(
+          (e) => e.kind === "cardPlacement",
+        )[1] as any;
+        expect(update.hand).toHaveLength(2);
+        expect(update.deck).toHaveLength(1);
+        expect(update.discardPile).toHaveLength(0);
+        expect(update.removedCardPile).toBeUndefined();
+      });
+      test("「アイドル宣言」を、手札最大枚数が超える状況で使った時、手札は最大枚数で、捨札が増える", () => {
+        const lesson = createLessonForTest({
+          cards: [
+            {
+              id: "a",
+              definition: getCardDataById("aidorusengen"),
+              enabled: true,
+              enhanced: false,
+            },
+            ...["b", "c", "d", "e", "f", "g"].map((id) => ({
+              id,
+              definition: getCardDataById("apirunokihon"),
+              enabled: true,
+              enhanced: false,
+            })),
+          ],
+        });
+        lesson.hand = ["a", "b", "c", "d", "e"];
+        lesson.deck = ["f", "g"];
+        const { updates } = useCard(lesson, 1, {
+          selectedCardInHandIndex: 0,
+          getRandom: () => 0,
+          idGenerator: createIdGenerator(),
+        });
+        // 手札使用時の更新があるため、効果による手札増加は2番目の更新になる
+        const update = updates.filter(
+          (e) => e.kind === "cardPlacement",
+        )[1] as any;
+        expect(update.hand).toHaveLength(5);
+        expect(update.deck).toHaveLength(0);
+        expect(update.discardPile).toHaveLength(1);
+        expect(update.removedCardPile).toBeUndefined();
+      });
+    });
+    describe("enhanceHand", () => {
+      test("「ティーパーティ」は、自分以外の、プロデュース中またはレッスン中に強化していない手札のみを強化する", () => {
+        const lesson = createLessonForTest({
+          cards: [
+            {
+              id: "a",
+              definition: getCardDataById("teipatei"),
+              enabled: true,
+              enhanced: false,
+            },
+            ...["b", "c", "d"].map((id) => ({
+              id,
+              definition: getCardDataById("apirunokihon"),
+              enabled: true,
+              enhanced: false,
+            })),
+            ...["e"].map((id) => ({
+              id,
+              definition: getCardDataById("apirunokihon"),
+              enabled: true,
+              enhanced: true,
+            })),
+          ],
+        });
+        lesson.hand = ["a", "b", "c", "d", "e"];
+        const dCard = lesson.cards.find((e) => e.id === "d") as Card;
+        dCard.enhancements = [{ kind: "effect" }];
+        const { updates } = useCard(lesson, 1, {
+          selectedCardInHandIndex: 0,
+          getRandom: () => 0,
+          idGenerator: createIdGenerator(),
+        });
+        const enhancedCardIds = (
+          updates.find((e) => e.kind === "cardEnhancement") as any
+        ).cardIds;
+        expect(enhancedCardIds).not.toContain("a");
+        expect(enhancedCardIds).toContain("b");
+        expect(enhancedCardIds).toContain("c");
+        expect(enhancedCardIds).not.toContain("d");
+        expect(enhancedCardIds).not.toContain("e");
+      });
+    });
+    describe("exchangeHand", () => {
+      test("「仕切り直し」を、手札3枚の状況で使った時、残りの手札は捨札へ入り、手札は山札から引いた新しい2枚になる", () => {
+        const lesson = createLessonForTest({
+          cards: [
+            {
+              id: "a",
+              definition: getCardDataById("shikirinaoshi"),
+              enabled: true,
+              enhanced: false,
+            },
+            ...["b", "c", "d", "e", "f"].map((id) => ({
+              id,
+              definition: getCardDataById("apirunokihon"),
+              enabled: true,
+              enhanced: false,
+            })),
+          ],
+        });
+        lesson.hand = ["a", "b", "c"];
+        lesson.deck = ["d", "e"];
+        lesson.discardPile = ["f"];
+        const { updates } = useCard(lesson, 1, {
+          selectedCardInHandIndex: 0,
+          getRandom: () => 0,
+          idGenerator: createIdGenerator(),
+        });
+        // 手札使用時の更新があるため、効果による手札増加は2番目の更新になる
+        const update = updates.filter(
+          (e) => e.kind === "cardPlacement",
+        )[1] as any;
+        expect(update.hand).toHaveLength(2);
+        expect(update.hand).toContain("d");
+        expect(update.hand).toContain("e");
+        expect(update.deck).toHaveLength(0);
+        expect(update.discardPile).toHaveLength(3);
+        expect(update.discardPile).toContain("b");
+        expect(update.discardPile).toContain("c");
+        expect(update.discardPile).toContain("f");
+        expect(update.removedCardPile).toBeUndefined();
+      });
+    });
+    describe("generateCard", () => {
+      test("強化済みのSSRカードを生成して手札に入る", () => {
+        const lesson = createLessonForTest({
+          cards: [
+            {
+              id: "a",
+              definition: getCardDataById("hanamoyukisetsu"),
+              enabled: true,
+              enhanced: false,
+            },
+          ],
+        });
+        lesson.hand = ["a"];
+        const { updates } = useCard(lesson, 1, {
+          selectedCardInHandIndex: 0,
+          getRandom: () => 0,
+          idGenerator: createIdGenerator(),
+        });
+        const cardsUpdate = updates.find((e) => e.kind === "cards") as any;
+        // アイドル固有 + 上記で足している hanamoyukisetsu + 生成したカード
+        expect(cardsUpdate.cards).toHaveLength(3);
+        expect(cardsUpdate.cards[2].enhancements).toStrictEqual([
+          {
+            kind: "original",
+          },
+        ]);
+        expect(cardsUpdate.cards[2].original.definition.rarity).toBe("ssr");
+        const cardPlacementUpdate = updates
+          .slice()
+          .reverse()
+          .find((e) => e.kind === "cardPlacement") as any;
+        expect(cardPlacementUpdate).toStrictEqual({
+          kind: "cardPlacement",
+          hand: expect.any(Array),
+          reason: expect.any(Object),
+        });
+      });
+    });
+    describe("getModifier", () => {
+      test("it works", () => {
+        const lesson = createLessonForTest({
+          cards: [
+            {
+              id: "a",
+              definition: getCardDataById("furumainokihon"),
+              enabled: true,
+              enhanced: false,
+            },
+          ],
+        });
+        lesson.hand = ["a"];
+        const { updates } = useCard(lesson, 1, {
+          selectedCardInHandIndex: 0,
+          getRandom: () => 0,
+          idGenerator: createIdGenerator(),
+        });
+        const update = updates.find((e) => e.kind === "modifier") as any;
+        expect(update).toStrictEqual({
+          kind: "modifier",
+          modifier: {
+            kind: "goodCondition",
+            duration: 2,
+          },
+          reason: expect.any(Object),
+        });
+      });
+    });
+    describe("increaseRemainingTurns", () => {
+      test("it works", () => {
+        const lesson = createLessonForTest({
+          cards: [
+            {
+              id: "a",
+              definition: getCardDataById("watashigasta"),
+              enabled: true,
+              enhanced: false,
+            },
+          ],
+        });
+        lesson.hand = ["a"];
+        lesson.idol.modifiers = [{ kind: "positiveImpression", amount: 2 }];
+        const { updates } = useCard(lesson, 1, {
+          selectedCardInHandIndex: 0,
+          getRandom: () => 0,
+          idGenerator: createIdGenerator(),
+        });
+        const update = updates.find((e) => e.kind === "remainingTurns") as any;
+        expect(update).toStrictEqual({
+          kind: "remainingTurns",
+          amount: 1,
+          reason: expect.any(Object),
+        });
+      });
+    });
+    describe("multiplyModifier", () => {
+      test("it works", () => {
+        // この効果を持つスキルカードがないので、モックを作る
+        const cardDefinitionMock = {
+          base: {
+            cost: { kind: "normal", value: 0 },
+            effects: [
+              {
+                kind: "multiplyModifier",
+                modifierKind: "positiveImpression",
+                multiplier: 1.5,
+              },
+            ],
+          },
+        } as CardDefinition;
+        const lesson = createLessonForTest({
+          cards: [
+            {
+              id: "a",
+              definition: cardDefinitionMock,
+              enabled: true,
+              enhanced: false,
+            },
+          ],
+        });
+        lesson.hand = ["a"];
+        lesson.idol.modifiers = [
+          { kind: "focus", amount: 20 },
+          { kind: "positiveImpression", amount: 10 },
+        ];
+        const { updates } = useCard(lesson, 1, {
+          selectedCardInHandIndex: 0,
+          getRandom: () => 0,
+          idGenerator: createIdGenerator(),
+        });
+        const update = updates.find((e) => e.kind === "modifier") as any;
+        expect(update).toStrictEqual({
+          kind: "modifier",
+          modifier: {
+            kind: "positiveImpression",
+            amount: 5,
+          },
+          reason: expect.any(Object),
+        });
+      });
+    });
+    // calculatePerformingScoreEffect と calculatePerformingVitalityEffect のテストで検証できる内容はそちらで行う
+    describe("perform", () => {
+      test("レッスンにスコア上限がある時、スコアはそれを超えない増加値を返す", () => {
+        const lesson = createLessonForTest({
+          cards: [
+            {
+              id: "a",
+              definition: getCardDataById("apirunokihon"),
+              enabled: true,
+              enhanced: false,
+            },
+          ],
+        });
+        lesson.hand = ["a"];
+        lesson.score = 9;
+        lesson.clearScoreThresholds = {
+          clear: 5,
+          perfect: 10,
+        };
+        const { updates } = useCard(lesson, 1, {
+          selectedCardInHandIndex: 0,
+          getRandom: () => 0,
+          idGenerator: createIdGenerator(),
+        });
+        const filtered = updates.filter((e) => e.kind === "score") as any[];
+        expect(filtered).toStrictEqual([
+          {
+            kind: "score",
+            actual: 1,
+            max: 9,
+            reason: expect.any(Object),
+          },
+        ]);
+      });
+      test("クリアスコアの設定だけありパーフェクトの設定がない時、レッスンにスコア上限はないと判断する", () => {
+        const lesson = createLessonForTest({
+          cards: [
+            {
+              id: "a",
+              definition: getCardDataById("apirunokihon"),
+              enabled: true,
+              enhanced: false,
+            },
+          ],
+        });
+        lesson.hand = ["a"];
+        lesson.clearScoreThresholds = {
+          clear: 1,
+        };
+        const { updates } = useCard(lesson, 1, {
+          selectedCardInHandIndex: 0,
+          getRandom: () => 0,
+          idGenerator: createIdGenerator(),
+        });
+        const filtered = updates.filter((e) => e.kind === "score") as any[];
+        expect(filtered).toStrictEqual([
+          {
+            kind: "score",
+            actual: 9,
+            max: 9,
+            reason: expect.any(Object),
+          },
+        ]);
+      });
+      test("複数の更新を生成するスコア増加を返す", () => {
+        const lesson = createLessonForTest({
+          cards: [
+            {
+              id: "a",
+              definition: getCardDataById("shikosakugo"),
+              enabled: true,
+              enhanced: false,
+            },
+          ],
+        });
+        lesson.hand = ["a"];
+        const { updates } = useCard(lesson, 1, {
+          selectedCardInHandIndex: 0,
+          getRandom: () => 0,
+          idGenerator: createIdGenerator(),
+        });
+        const filtered = updates.filter((e) => e.kind === "score") as any[];
+        expect(filtered).toStrictEqual([
+          {
+            kind: "score",
+            actual: 8,
+            max: 8,
+            reason: expect.any(Object),
+          },
+          {
+            kind: "score",
+            actual: 8,
+            max: 8,
+            reason: expect.any(Object),
+          },
+        ]);
+      });
+      test("スコアと元気の更新を同時に返す", () => {
+        const lesson = createLessonForTest({
+          cards: [
+            {
+              id: "a",
+              definition: getCardDataById("pozunokihon"),
+              enabled: true,
+              enhanced: false,
+            },
+          ],
+        });
+        lesson.hand = ["a"];
+        const { updates } = useCard(lesson, 1, {
+          selectedCardInHandIndex: 0,
+          getRandom: () => 0,
+          idGenerator: createIdGenerator(),
+        });
+        const filtered = updates.filter(
+          (e) => e.kind === "score" || e.kind === "vitality",
+        ) as any[];
+        expect(filtered).toStrictEqual([
+          {
+            kind: "score",
+            actual: 2,
+            max: 2,
+            reason: expect.any(Object),
+          },
+          {
+            kind: "vitality",
+            actual: 2,
+            max: 2,
+            reason: expect.any(Object),
+          },
+        ]);
+      });
+    });
+    describe("performLeveragingModifier", () => {
+      test("motivation", () => {
+        const lesson = createLessonForTest({
+          cards: [
+            {
+              id: "a",
+              definition: getCardDataById("kaika"),
+              enabled: true,
+              enhanced: false,
+            },
+          ],
+        });
+        lesson.hand = ["a"];
+        lesson.idol.modifiers = [{ kind: "motivation", amount: 10 }];
+        const { updates } = useCard(lesson, 1, {
+          selectedCardInHandIndex: 0,
+          getRandom: () => 0,
+          idGenerator: createIdGenerator(),
+        });
+        const update = updates.find((e) => e.kind === "score") as any;
+        expect(update).toStrictEqual({
+          kind: "score",
+          actual: 20,
+          max: 20,
+          reason: expect.any(Object),
+        });
+      });
+      test("positiveImpression", () => {
+        const lesson = createLessonForTest({
+          cards: [
+            {
+              id: "a",
+              definition: getCardDataById("200sumairu"),
+              enabled: true,
+              enhanced: false,
+            },
+          ],
+        });
+        lesson.hand = ["a"];
+        lesson.idol.modifiers = [{ kind: "positiveImpression", amount: 10 }];
+        const { updates } = useCard(lesson, 1, {
+          selectedCardInHandIndex: 0,
+          getRandom: () => 0,
+          idGenerator: createIdGenerator(),
+        });
+        const update = updates.find((e) => e.kind === "score") as any;
+        expect(update).toStrictEqual({
+          kind: "score",
+          actual: 10,
+          max: 10,
+          reason: expect.any(Object),
+        });
+      });
+      test("スコア上限の設定がある時は、actualはその値を超えない", () => {
+        const lesson = createLessonForTest({
+          cards: [
+            {
+              id: "a",
+              definition: getCardDataById("kaika"),
+              enabled: true,
+              enhanced: false,
+            },
+          ],
+        });
+        lesson.hand = ["a"];
+        lesson.clearScoreThresholds = {
+          clear: 1,
+          perfect: 6,
+        };
+        lesson.idol.modifiers = [{ kind: "motivation", amount: 5 }];
+        const { updates } = useCard(lesson, 1, {
+          selectedCardInHandIndex: 0,
+          getRandom: () => 0,
+          idGenerator: createIdGenerator(),
+        });
+        const update = updates.find((e) => e.kind === "score") as any;
+        expect(update).toStrictEqual({
+          kind: "score",
+          actual: 6,
+          max: 10,
+          reason: expect.any(Object),
+        });
+      });
+    });
+    describe("performLeveragingVitality", () => {
+      test("通常", () => {
+        const lesson = createLessonForTest({
+          cards: [
+            {
+              id: "a",
+              definition: getCardDataById("genkinaaisatsu"),
+              enabled: true,
+              enhanced: false,
+            },
+          ],
+        });
+        lesson.hand = ["a"];
+        lesson.idol.vitality = 10;
+        const { updates } = useCard(lesson, 1, {
+          selectedCardInHandIndex: 0,
+          getRandom: () => 0,
+          idGenerator: createIdGenerator(),
+        });
+        const update = updates.find((e) => e.kind === "score") as any;
+        expect(update).toStrictEqual({
+          kind: "score",
+          actual: 11,
+          max: 11,
+          reason: expect.any(Object),
+        });
+      });
+      test("50%の元気を消費、端数は切り捨て", () => {
+        const lesson = createLessonForTest({
+          cards: [
+            {
+              id: "a",
+              definition: getCardDataById("hatonoaizu"),
+              enabled: true,
+              enhanced: false,
+            },
+          ],
+        });
+        lesson.hand = ["a"];
+        lesson.idol.vitality = 11;
+        const { updates } = useCard(lesson, 1, {
+          selectedCardInHandIndex: 0,
+          getRandom: () => 0,
+          idGenerator: createIdGenerator(),
+        });
+        const update = updates.find((e) => e.kind === "vitality") as any;
+        expect(update).toStrictEqual({
+          kind: "vitality",
+          actual: -5,
+          max: -5,
+          reason: expect.any(Object),
+        });
+      });
+      test("100%の元気を消費", () => {
+        const lesson = createLessonForTest({
+          cards: [
+            {
+              id: "a",
+              definition: getCardDataById("todoite"),
+              enabled: true,
+              enhanced: false,
+            },
+          ],
+        });
+        lesson.hand = ["a"];
+        lesson.idol.vitality = 10;
+        const { updates } = useCard(lesson, 1, {
+          selectedCardInHandIndex: 0,
+          getRandom: () => 0,
+          idGenerator: createIdGenerator(),
+        });
+        const update = updates.find((e) => e.kind === "vitality") as any;
+        expect(update).toStrictEqual({
+          kind: "vitality",
+          actual: -10,
+          max: -10,
+          reason: expect.any(Object),
+        });
+      });
+    });
+    describe("recoverLife", () => {
+      test("通常", () => {
+        const lesson = createLessonForTest({
+          cards: [
+            {
+              id: "a",
+              definition: getCardDataById("hoyoryoku"),
+              enabled: true,
+              enhanced: false,
+            },
+          ],
+        });
+        lesson.hand = ["a"];
+        lesson.idol.life = 10;
+        const { updates } = useCard(lesson, 1, {
+          selectedCardInHandIndex: 0,
+          getRandom: () => 0,
+          idGenerator: createIdGenerator(),
+        });
+        const update = updates.find((e) => e.kind === "life") as any;
+        expect(update).toStrictEqual({
+          kind: "life",
+          actual: 2,
+          max: 2,
+          reason: expect.any(Object),
+        });
+      });
+      test("体力上限を超えて回復しない", () => {
+        const lesson = createLessonForTest({
+          cards: [
+            {
+              id: "a",
+              definition: getCardDataById("hoyoryoku"),
+              enabled: true,
+              enhanced: false,
+            },
+          ],
+        });
+        lesson.hand = ["a"];
+        lesson.idol.life = lesson.idol.original.maxLife;
+        const { updates } = useCard(lesson, 1, {
+          selectedCardInHandIndex: 0,
+          getRandom: () => 0,
+          idGenerator: createIdGenerator(),
+        });
+        const update = updates.find((e) => e.kind === "life") as any;
+        expect(update).toStrictEqual({
+          kind: "life",
+          actual: 0,
+          max: 2,
+          reason: expect.any(Object),
+        });
+      });
+    });
+  });
+  describe("状態修正によるスキルカード使用毎効果発動", () => {
+    test("「ファンシーチャーム」は、メンタルスキルカード使用時、好印象を付与する。アクティブスキルカード使用時は付与しない", () => {
+      let lesson = createLessonForTest({
+        cards: [
+          {
+            id: "a",
+            definition: getCardDataById("fanshichamu"),
+            enabled: true,
+            enhanced: false,
+          },
+          {
+            id: "b",
+            definition: getCardDataById("hyogennokihon"),
+            enabled: true,
+            enhanced: false,
+          },
+          {
+            id: "c",
+            definition: getCardDataById("apirunokihon"),
+            enabled: true,
+            enhanced: false,
+          },
+        ],
+      });
+      lesson.hand = ["a", "b", "c"];
+      const idGenerator = createIdGenerator();
+      const { updates: updates1 } = useCard(lesson, 1, {
+        selectedCardInHandIndex: 0,
+        getRandom: () => 0,
+        idGenerator,
+      });
+      expect(updates1.filter((e) => e.kind === "modifier")).toStrictEqual([
+        // 「ファンシーチャーム」には、直接好印象を付与する効果もある
+        {
+          kind: "modifier",
+          modifier: {
+            kind: "positiveImpression",
+            amount: 3,
+          },
+          reason: expect.any(Object),
+        },
+        {
+          kind: "modifier",
+          modifier: {
+            kind: "effectActivationUponCardUsage",
+            cardKind: "mental",
+            effect: expect.any(Object),
+          },
+          reason: expect.any(Object),
+        },
+      ]);
+
+      lesson = patchUpdates(lesson, updates1);
+
+      const { updates: updates2a } = useCard(lesson, 2, {
+        selectedCardInHandIndex: 0,
+        getRandom: () => 0,
+        idGenerator,
+      });
+      expect(updates2a.filter((e) => e.kind === "modifier")).toStrictEqual([
+        {
+          kind: "modifier",
+          modifier: {
+            kind: "positiveImpression",
+            amount: 1,
+          },
+          reason: expect.any(Object),
+        },
+      ]);
+
+      const { updates: updates2b } = useCard(lesson, 2, {
+        selectedCardInHandIndex: 1,
+        getRandom: () => 0,
+        idGenerator,
+      });
+      expect(updates2b.filter((e) => e.kind === "modifier")).toHaveLength(0);
+    });
+    test("「演出計画」は、アクティブスキルカード使用時、固定元気を付与する。メンタルスキルカード使用時は付与しない", () => {
+      let lesson = createLessonForTest({
+        cards: [
+          {
+            id: "a",
+            definition: getCardDataById("enshutsukeikaku"),
+            enabled: true,
+            enhanced: false,
+          },
+          {
+            id: "b",
+            definition: getCardDataById("apirunokihon"),
+            enabled: true,
+            enhanced: false,
+          },
+          {
+            id: "c",
+            definition: getCardDataById("shinkokyu"),
+            enabled: true,
+            enhanced: false,
+          },
+        ],
+      });
+      lesson.hand = ["a", "b", "c"];
+      const idGenerator = createIdGenerator();
+      const { updates: updates1 } = useCard(lesson, 1, {
+        selectedCardInHandIndex: 0,
+        getRandom: () => 0,
+        idGenerator,
+      });
+      expect(updates1.filter((e) => e.kind === "modifier")).toStrictEqual([
+        // 「演出計画」には、直接絶好調を付与する効果もある
+        {
+          kind: "modifier",
+          modifier: {
+            kind: "excellentCondition",
+            duration: 3,
+          },
+          reason: expect.any(Object),
+        },
+        {
+          kind: "modifier",
+          modifier: {
+            kind: "effectActivationUponCardUsage",
+            cardKind: "active",
+            effect: expect.any(Object),
+          },
+          reason: expect.any(Object),
+        },
+      ]);
+
+      lesson = patchUpdates(lesson, updates1);
+
+      const { updates: updates2a } = useCard(lesson, 2, {
+        selectedCardInHandIndex: 0,
+        getRandom: () => 0,
+        idGenerator,
+      });
+      expect(updates2a.filter((e) => e.kind === "vitality")).toStrictEqual([
+        {
+          kind: "vitality",
+          actual: 2,
+          max: 2,
+          reason: expect.any(Object),
+        },
+      ]);
+
+      const { updates: updates2b } = useCard(lesson, 2, {
+        selectedCardInHandIndex: 1,
+        getRandom: () => 0,
+        idGenerator,
+      });
+      expect(updates2b.filter((e) => e.kind === "vitality")).toHaveLength(0);
+    });
+  });
+});

--- a/src/lesson-mutation.ts
+++ b/src/lesson-mutation.ts
@@ -1,0 +1,1077 @@
+import type {
+  ActionCost,
+  Card,
+  CardContentDefinition,
+  CardInProduction,
+  CardUsageCondition,
+  Effect,
+  EffectCondition,
+  GetRandom,
+  IdGenerator,
+  Idol,
+  Lesson,
+  LessonUpdateQuery,
+  LessonUpdateQueryDiff,
+  LessonUpdateQueryReason,
+  Modifier,
+  VitalityUpdateQuery,
+} from "./types";
+import { filterGeneratableCardsData } from "./data/card";
+import {
+  calculateActualActionCost,
+  calculateActualRemainingTurns,
+  calculateClearScoreProgress,
+  maxHandSize,
+  patchUpdates,
+  prepareCardsForLesson,
+} from "./models";
+import { shuffleArray, validateNumberInRange } from "./utils";
+
+/** 主に型都合のユーティリティ処理 */
+const createLessonUpdateQueryFromDiff = (
+  diff: LessonUpdateQueryDiff,
+  reason: LessonUpdateQueryReason,
+): LessonUpdateQuery => ({ ...diff, reason });
+
+const getCardContentDefinition = (card: Card): CardContentDefinition => {
+  return card.original.definition.enhanced !== undefined &&
+    card.enhancements.length > 0
+    ? card.original.definition.enhanced
+    : card.original.definition.base;
+};
+
+/**
+ * 山札から指定数のスキルカードを引く
+ *
+ * - 山札がなくなった場合は、捨札をシャッフルして山札にする
+ */
+export const drawCardsFromDeck = (
+  deck: Lesson["deck"],
+  count: number,
+  discardPile: Lesson["discardPile"],
+  getRandom: GetRandom,
+): {
+  deck: Array<Card["id"]>;
+  discardPile: Array<Card["id"]>;
+  drawnCards: Array<Card["id"]>;
+} => {
+  let newDeck = [...deck];
+  let newDiscardPile = [...discardPile];
+  let drawnCards = [];
+  for (let i = 0; i < count; i++) {
+    // 捨札を加えても引く数に足りない状況は考慮しない
+    if (newDeck.length === 0) {
+      newDeck = shuffleArray(newDiscardPile, getRandom);
+      newDiscardPile = [];
+    }
+    const drawnCard = newDeck.shift();
+    if (!drawnCard) {
+      throw new Error("Unexpected empty deck");
+    }
+    drawnCards.push(drawnCard);
+  }
+  return {
+    deck: newDeck,
+    discardPile: newDiscardPile,
+    drawnCards,
+  };
+};
+
+/**
+ * スキルカードを手札へ加える
+ *
+ * - 山札から引いた時、レッスン開始時手札を引く時、生成した時、などに使う
+ * - 手札が最大枚数の5枚に達した以降は、引いたスキルカードは手札へ加えずに捨札へ移動する
+ * - TODO: [仕様確認] 最大手札数は本当に5枚か？
+ * - TODO: [仕様確認] 最大手札数を超えて引いた時の捨札へ直行する挙動自体、記憶によるとなので本当かわからない
+ */
+export const addCardsToHandOrDiscardPile = (
+  drawnCards: Array<Card["id"]>,
+  hand: Lesson["hand"],
+  discardPile: Lesson["discardPile"],
+): {
+  hand: Lesson["hand"];
+  discardPile: Lesson["discardPile"];
+} => {
+  const newHand = [...hand];
+  const newDiscardPile = [...discardPile];
+  for (const drawnCard of drawnCards) {
+    if (newHand.length < maxHandSize) {
+      newHand.push(drawnCard);
+    } else {
+      newDiscardPile.push(drawnCard);
+    }
+  }
+  return {
+    hand: newHand,
+    discardPile: newDiscardPile,
+  };
+};
+
+export const createCardPlacementDiff = (
+  before: {
+    deck?: Lesson["deck"];
+    discardPile?: Lesson["discardPile"];
+    hand?: Lesson["hand"];
+    removedCardPile?: Lesson["removedCardPile"];
+  },
+  after: {
+    deck?: Lesson["deck"];
+    discardPile?: Lesson["discardPile"];
+    hand?: Lesson["hand"];
+    removedCardPile?: Lesson["removedCardPile"];
+  },
+): Extract<LessonUpdateQueryDiff, { kind: "cardPlacement" }> => {
+  return {
+    kind: "cardPlacement" as const,
+    ...(before.deck !== undefined &&
+    after.deck !== undefined &&
+    JSON.stringify(before.deck) !== JSON.stringify(after.deck)
+      ? { deck: after.deck }
+      : {}),
+    ...(before.discardPile !== undefined &&
+    after.discardPile !== undefined &&
+    JSON.stringify(before.discardPile) !== JSON.stringify(after.discardPile)
+      ? { discardPile: after.discardPile }
+      : {}),
+    ...(before.hand !== undefined &&
+    after.hand !== undefined &&
+    JSON.stringify(before.hand) !== JSON.stringify(after.hand)
+      ? { hand: after.hand }
+      : {}),
+    ...(before.removedCardPile !== undefined &&
+    after.removedCardPile !== undefined &&
+    JSON.stringify(before.removedCardPile) !==
+      JSON.stringify(after.removedCardPile)
+      ? { removedCardPile: after.removedCardPile }
+      : {}),
+  };
+};
+
+type LessonMutationResult = {
+  nextHistoryResultIndex: LessonUpdateQuery["reason"]["historyResultIndex"];
+  updates: LessonUpdateQuery[];
+};
+
+/**
+ * ターン開始時に手札を引く
+ *
+ * - TODO: レッスン開始時に手札
+ */
+export const drawCardsOnLessonStart = (
+  lesson: Lesson,
+  params: {
+    count: number;
+    getRandom: GetRandom;
+    historyResultIndex: LessonUpdateQuery["reason"]["historyResultIndex"];
+  },
+): LessonUpdateQuery[] => {
+  const { deck, discardPile, drawnCards } = drawCardsFromDeck(
+    lesson.deck,
+    params.count,
+    lesson.discardPile,
+    params.getRandom,
+  );
+  const { hand: hand2, discardPile: discardPile2 } =
+    addCardsToHandOrDiscardPile(drawnCards, lesson.hand, discardPile);
+  return [
+    {
+      ...createCardPlacementDiff(
+        {
+          deck: lesson.deck,
+          discardPile: lesson.discardPile,
+          hand: lesson.hand,
+        },
+        {
+          deck,
+          discardPile: discardPile2,
+          hand: hand2,
+        },
+      ),
+      reason: {
+        kind: "lessonStartTrigger",
+        historyTurnNumber: lesson.turnNumber,
+        historyResultIndex: params.historyResultIndex,
+      },
+    },
+  ];
+};
+
+/**
+ * 手札使用のプレビュー表示をするか表示を解除する
+ *
+ * - コストを満たさない状態でもプレビューはできる
+ *   - 足りないコストは、ゼロとして差分表示される
+ * - カードを引く効果や「生成」効果など、一部の効果はプレビューできない
+ */
+export const previewCardUsage = (
+  lesson: Lesson,
+  historyResultIndex: LessonUpdateQuery["reason"]["historyResultIndex"],
+  params: {
+    selectedCardInHandIndex: number | undefined;
+  },
+): LessonMutationResult => {
+  return {
+    nextHistoryResultIndex: historyResultIndex + 1,
+    updates: [
+      {
+        kind: "selectedCardInHandIndex",
+        index: params.selectedCardInHandIndex,
+        reason: {
+          kind: "cardUsagePreview",
+          historyTurnNumber: lesson.turnNumber,
+          historyResultIndex,
+        },
+      },
+    ],
+  };
+};
+
+/** アイドルがコスト分のリソースを持つかを検証する */
+export const validateCostComsumution = (
+  idol: Idol,
+  cost: ActionCost,
+): boolean => {
+  const actualCost = calculateActualActionCost(cost, idol.modifiers);
+  const actualCostKind = actualCost.kind;
+  switch (actualCostKind) {
+    case "focus": {
+      const focus = idol.modifiers.find((e) => e.kind === "focus");
+      const focusAmount = focus && "amount" in focus ? focus.amount : 0;
+      return actualCost.value <= focusAmount;
+    }
+    case "goodCondition": {
+      const goodCondition = idol.modifiers.find(
+        (e) => e.kind === "goodCondition",
+      );
+      const goodConditionDuration =
+        goodCondition && "duration" in goodCondition
+          ? goodCondition.duration
+          : 0;
+      return actualCost.value <= goodConditionDuration;
+    }
+    case "life": {
+      return actualCost.value <= idol.life;
+    }
+    case "motivation": {
+      const motivation = idol.modifiers.find((e) => e.kind === "motivation");
+      const motivationAmount =
+        motivation && "amount" in motivation ? motivation.amount : 0;
+      return actualCost.value <= motivationAmount;
+    }
+    case "normal": {
+      return actualCost.value <= idol.life + idol.vitality;
+    }
+    case "positiveImpression": {
+      const positiveImpression = idol.modifiers.find(
+        (e) => e.kind === "positiveImpression",
+      );
+      const positiveImpressionAmount =
+        positiveImpression && "amount" in positiveImpression
+          ? positiveImpression.amount
+          : 0;
+      return actualCost.value <= positiveImpressionAmount;
+    }
+    default: {
+      const unreachable: never = actualCostKind;
+      throw new Error(`Unreachable statement`);
+    }
+  }
+};
+
+/** スキルカードが使用できるかを判定する */
+export const canUseCard = (
+  lesson: Lesson,
+  cost: ActionCost,
+  condition: CardUsageCondition | undefined,
+): boolean => {
+  const costValidation = validateCostComsumution(lesson.idol, cost);
+  if (!costValidation) {
+    return false;
+  }
+  if (!condition) {
+    return true;
+  }
+  const conditionKind = condition.kind;
+  switch (conditionKind) {
+    case "countTurnNumber": {
+      return lesson.turnNumber >= condition.min;
+    }
+    case "countVitalityZero": {
+      return lesson.idol.vitality === 0;
+    }
+    case "hasGoodCondition": {
+      return (
+        lesson.idol.modifiers.find((e) => e.kind === "goodCondition") !==
+        undefined
+      );
+    }
+    case "measureValue": {
+      let targetPercentage: number | undefined = undefined;
+      const valueKind = condition.valueKind;
+      switch (valueKind) {
+        case "life": {
+          targetPercentage = Math.floor(
+            (lesson.idol.life * 100) / lesson.idol.original.maxLife,
+          );
+          break;
+        }
+        case "score": {
+          if (lesson.clearScoreThresholds) {
+            const result = calculateClearScoreProgress(
+              lesson.score,
+              lesson.clearScoreThresholds,
+            );
+            targetPercentage = result.clearScoreProgressPercentage;
+          }
+          break;
+        }
+        default: {
+          const unreachable: never = valueKind;
+          throw new Error(`Unreachable statement`);
+        }
+      }
+      if (targetPercentage === undefined) {
+        return true;
+      }
+      const criterionKind = condition.criterionKind;
+      switch (criterionKind) {
+        case "greaterEqual": {
+          return targetPercentage >= condition.percentage;
+        }
+        case "lessEqual": {
+          return targetPercentage <= condition.percentage;
+        }
+        default: {
+          const unreachable: never = criterionKind;
+          throw new Error(`Unreachable statement`);
+        }
+      }
+    }
+    default: {
+      const unreachable: never = conditionKind;
+      throw new Error(`Unreachable statement`);
+    }
+  }
+};
+
+/** 各効果が適用できるかを判定する */
+export const canApplyEffect = (
+  lesson: Lesson,
+  condition: EffectCondition,
+): boolean => {
+  const conditionKind = condition.kind;
+  switch (conditionKind) {
+    case "countModifier": {
+      let targetValue: number;
+      const modifierKind = condition.modifierKind;
+      switch (modifierKind) {
+        case "focus": {
+          const focus = lesson.idol.modifiers.find((e) => e.kind === "focus");
+          targetValue = focus && "amount" in focus ? focus.amount : 0;
+          break;
+        }
+        case "motivation": {
+          const motivation = lesson.idol.modifiers.find(
+            (e) => e.kind === "motivation",
+          );
+          targetValue =
+            motivation && "amount" in motivation ? motivation.amount : 0;
+          break;
+        }
+        case "positiveImpression": {
+          const positiveImpression = lesson.idol.modifiers.find(
+            (e) => e.kind === "positiveImpression",
+          );
+          targetValue =
+            positiveImpression && "amount" in positiveImpression
+              ? positiveImpression.amount
+              : 0;
+          break;
+        }
+        default: {
+          const unreachable: never = modifierKind;
+          throw new Error(`Unreachable statement`);
+        }
+      }
+      return targetValue >= condition.min;
+    }
+    case "countReminingTurns": {
+      return calculateActualRemainingTurns(lesson) <= condition.max;
+    }
+    case "countVitality": {
+      return validateNumberInRange(lesson.idol.vitality, condition.range);
+    }
+    case "hasGoodCondition": {
+      return (
+        lesson.idol.modifiers.find((e) => e.kind === "goodCondition") !==
+        undefined
+      );
+    }
+    case "measureIfLifeIsEqualGreaterThanHalf": {
+      const percentage = Math.floor(
+        (lesson.idol.life * 100) / lesson.idol.original.maxLife,
+      );
+      return percentage >= 50;
+    }
+    default: {
+      const unreachable: never = conditionKind;
+      throw new Error(`Unreachable statement`);
+    }
+  }
+};
+
+const calculateActualAndMaxComsumution = (
+  resourceValue: number,
+  costValue: number,
+) => {
+  return {
+    actual: costValue > resourceValue ? -resourceValue : -costValue,
+    max: -costValue,
+    restCost: resourceValue > costValue ? 0 : costValue - resourceValue,
+  };
+};
+
+/** LessonUpdateQueryDiff からコスト消費関係部分を抜き出したもの */
+type CostConsumptionUpdateQueryDiff = Extract<
+  LessonUpdateQueryDiff,
+  { kind: "life" } | { kind: "modifier" } | { kind: "vitality" }
+>;
+
+/**
+ * コスト消費を計算する
+ *
+ * - 消費分のコストは足りる前提で呼び出す
+ */
+const calculateCostConsumption = (
+  idol: Idol,
+  cost: ActionCost,
+): CostConsumptionUpdateQueryDiff[] => {
+  switch (cost.kind) {
+    case "normal": {
+      const updates: CostConsumptionUpdateQueryDiff[] = [];
+      let restCost = cost.value;
+      if (idol.vitality > 0) {
+        const result = calculateActualAndMaxComsumution(
+          idol.vitality,
+          restCost,
+        );
+        restCost = result.restCost;
+        updates.push({
+          kind: "vitality",
+          actual: result.actual,
+          max: result.max,
+        });
+      }
+      if (restCost > 0) {
+        const result = calculateActualAndMaxComsumution(idol.life, restCost);
+        updates.push({
+          kind: "life",
+          actual: result.actual,
+          max: result.max,
+        });
+      }
+      return updates;
+    }
+    case "life": {
+      return [
+        {
+          kind: "life",
+          actual: -cost.value,
+          max: -cost.value,
+        },
+      ];
+    }
+    case "focus":
+    case "motivation":
+    case "positiveImpression": {
+      return [
+        {
+          kind: "modifier",
+          modifier: {
+            kind: cost.kind,
+            amount: cost.value,
+          },
+        },
+      ];
+    }
+    case "goodCondition": {
+      return [
+        {
+          kind: "modifier",
+          modifier: {
+            kind: cost.kind,
+            duration: cost.value,
+          },
+        },
+      ];
+    }
+    default: {
+      const unreachable: never = cost.kind;
+      throw new Error(`Unreachable statement`);
+    }
+  }
+};
+
+/**
+ * スコア/パラメータ増加効果の計算をする
+ *
+ * - 本家 v1.2.0 での例
+ *   - 集中:0, 好調:1, 絶好調:無, アピールの基本（未強化, +9） => 14
+ *     - `9 * 1.5 = 13.5`
+ *   - 集中:4, 好調:6, 絶好調:有, ハイタッチ{未強化, +17, 集中*1.5} => 49
+ *     - `(17 + 4 * 1.5) * (1.5 + 0.6) = 48.30`
+ *   - 集中:4, 好調:6, 絶好調:有, ハイタッチ{強化済, +23, 集中*2.0} => 66
+ *     - `(23 + 4 * 2.0) * (1.5 + 0.6) = 65.10`
+ *   - 集中:4, 好調:6, 絶好調:有, 初星水（+10） => 30
+ *     - `(10 + 4) * (1.5 + 0.6) = 29.40`
+ * - TODO: 集中増幅効果が端数の時、そこで端数処理が入るのか、小数のまま計算されるのか。とりあえず小数のまま計算されると仮定している。
+ *
+ * @param remainingIncrementableScore 残りの増加可能スコア。undefined の場合は、無限大として扱う。
+ */
+export const calculatePerformingScoreEffect = (
+  idol: Idol,
+  remainingIncrementableScore: number | undefined,
+  query: NonNullable<Extract<Effect, { kind: "perform" }>["score"]>,
+): Array<Extract<LessonUpdateQueryDiff, { kind: "score" }>> => {
+  const goodCondition = idol.modifiers.find((e) => e.kind === "goodCondition");
+  const goodConditionDuration =
+    goodCondition && "duration" in goodCondition ? goodCondition.duration : 0;
+  const focus = idol.modifiers.find((e) => e.kind === "focus");
+  const focusAmount = focus && "amount" in focus ? focus.amount : 0;
+  const hasExcellentCondition =
+    idol.modifiers.find((e) => e.kind === "excellentCondition") !== undefined;
+  const hasMightyPerformance =
+    idol.modifiers.find((e) => e.kind === "mightyPerformance") !== undefined;
+  const focusMultiplier =
+    query.focusMultiplier !== undefined ? query.focusMultiplier : 1;
+  const score = Math.ceil(
+    (query.value + focusAmount * focusMultiplier) *
+      ((goodConditionDuration > 0 ? 1.5 : 1.0) +
+        (goodConditionDuration > 0 && hasExcellentCondition
+          ? goodConditionDuration * 0.1
+          : 0.0)) *
+      (hasMightyPerformance ? 1.5 : 1.0),
+  );
+  const diffs: Array<Extract<LessonUpdateQueryDiff, { kind: "score" }>> = [];
+  let remainingIncrementableScore_ = remainingIncrementableScore;
+  for (let i = 0; i < (query.times !== undefined ? query.times : 1); i++) {
+    diffs.push({
+      kind: "score",
+      actual:
+        remainingIncrementableScore_ !== undefined
+          ? Math.min(score, remainingIncrementableScore_)
+          : score,
+      max: score,
+    });
+    if (remainingIncrementableScore_ !== undefined) {
+      remainingIncrementableScore_ -= score;
+      remainingIncrementableScore_ = Math.max(remainingIncrementableScore_, 0);
+    }
+  }
+  return diffs;
+};
+
+export const calculatePerformingVitalityEffect = (
+  idol: Idol,
+  query: VitalityUpdateQuery,
+): Extract<LessonUpdateQueryDiff, { kind: "vitality" }> => {
+  if (query.fixedValue === true) {
+    return {
+      kind: "vitality",
+      actual: query.value,
+      max: query.value,
+    };
+  }
+  const motivation = idol.modifiers.find((e) => e.kind === "motivation");
+  const motivationAmount =
+    motivation && "amount" in motivation ? motivation.amount : 0;
+  const value =
+    query.value +
+    motivationAmount +
+    (query.boostPerCardUsed !== undefined
+      ? idol.totalCardUsageCount * query.boostPerCardUsed
+      : 0);
+  return {
+    kind: "vitality",
+    actual: value,
+    max: value,
+  };
+};
+
+/**
+ * 効果リストを計算して更新差分リストを返す
+ *
+ * - 1スキルカードや1Pアイテムが持つ効果リストに対して使う
+ * - 本処理内では、レッスンその他の状況は変わらない前提
+ *   - 「お嬢様の晴れ舞台」で、最初に加算される元気は、その後のパラメータ上昇の計算には含まれていない、などのことから
+ */
+const computeEffects = (
+  lesson: Lesson,
+  effects: Effect[],
+  getRandom: GetRandom,
+  idGenerator: IdGenerator,
+): LessonUpdateQueryDiff[] => {
+  let remainingIncrementableScore: number | undefined;
+  if (lesson.clearScoreThresholds !== undefined) {
+    const progress = calculateClearScoreProgress(
+      lesson.score,
+      lesson.clearScoreThresholds,
+    );
+    if (progress.remainingPerfectScore !== undefined) {
+      remainingIncrementableScore = progress.remainingPerfectScore;
+    }
+  }
+  let diffs: LessonUpdateQueryDiff[] = [];
+  for (const effect of effects) {
+    //
+    // 効果別の適用条件判定
+    //
+    if (effect.condition) {
+      if (!canApplyEffect(lesson, effect.condition)) {
+        continue;
+      }
+    }
+
+    const effectKind = effect.kind;
+    switch (effectKind) {
+      // 現在は、Pアイテムの「私の「初」の楽譜」にのみ存在し、スキルカードには存在しない効果
+      case "drainLife": {
+        diffs.push({
+          kind: "life",
+          actual: Math.max(-effect.value, -lesson.idol.life),
+          max: -effect.value,
+        });
+        break;
+      }
+      case "drawCards": {
+        const { deck, discardPile, drawnCards } = drawCardsFromDeck(
+          lesson.deck,
+          effect.amount,
+          lesson.discardPile,
+          getRandom,
+        );
+        const { hand, discardPile: discardPile2 } = addCardsToHandOrDiscardPile(
+          drawnCards,
+          lesson.hand,
+          discardPile,
+        );
+        diffs.push(
+          createCardPlacementDiff(
+            {
+              deck: lesson.deck,
+              discardPile: lesson.discardPile,
+              hand: lesson.hand,
+            },
+            {
+              deck,
+              discardPile: discardPile2,
+              hand,
+            },
+          ),
+        );
+        break;
+      }
+      case "enhanceHand": {
+        diffs.push({
+          kind: "cardEnhancement",
+          // 手札の中で強化されていないスキルカードのみを対象にする
+          cardIds: lesson.hand.filter((id) => {
+            const card = lesson.cards.find((card) => card.id === id);
+            // この分岐に入ることはない想定、型ガード用
+            if (!card) {
+              return false;
+            }
+            return (
+              card.enhancements.find(
+                (e) => e.kind === "original" || e.kind === "effect",
+              ) === undefined
+            );
+          }),
+        });
+        break;
+      }
+      case "exchangeHand": {
+        const discardPile1 = [...lesson.discardPile, ...lesson.hand];
+        const {
+          deck,
+          discardPile: discardPile2,
+          drawnCards,
+        } = drawCardsFromDeck(
+          lesson.deck,
+          lesson.hand.length,
+          discardPile1,
+          getRandom,
+        );
+        const { hand, discardPile: discardPile3 } = addCardsToHandOrDiscardPile(
+          drawnCards,
+          [],
+          discardPile2,
+        );
+        diffs.push(
+          createCardPlacementDiff(
+            {
+              deck: lesson.deck,
+              discardPile: lesson.discardPile,
+              hand: lesson.hand,
+            },
+            {
+              deck,
+              discardPile: discardPile3,
+              hand,
+            },
+          ),
+        );
+        break;
+      }
+      case "generateCard": {
+        const candidates = filterGeneratableCardsData(
+          lesson.idol.original.definition.producePlan.kind,
+        );
+        const cardDefinition = candidates[getRandom() * candidates.length];
+        const cardInProduction: CardInProduction = {
+          id: idGenerator(),
+          definition: cardDefinition,
+          enabled: true,
+          enhanced: true,
+        };
+        const card: Card = prepareCardsForLesson([cardInProduction])[0];
+        const { hand, discardPile } = addCardsToHandOrDiscardPile(
+          [card.id],
+          lesson.hand,
+          lesson.discardPile,
+        );
+        diffs.push({
+          kind: "cards",
+          cards: [...lesson.cards, card],
+        });
+        diffs.push(
+          createCardPlacementDiff(
+            { hand: lesson.hand, discardPile: lesson.discardPile },
+            { hand, discardPile },
+          ),
+        );
+        break;
+      }
+      case "getModifier": {
+        diffs.push({
+          kind: "modifier",
+          modifier: effect.modifier,
+        });
+        break;
+      }
+      case "increaseRemainingTurns": {
+        diffs.push({
+          kind: "remainingTurns",
+          amount: effect.amount,
+        });
+        break;
+      }
+      case "multiplyModifier": {
+        const modifier = lesson.idol.modifiers.find(
+          (e) => e.kind === effect.modifierKind,
+        );
+        // 現在は、好印象に対してしか存在しない効果なので、そのこと前提で実装している
+        if (modifier?.kind === "positiveImpression") {
+          diffs.push({
+            kind: "modifier",
+            modifier: {
+              kind: "positiveImpression",
+              amount:
+                Math.ceil(modifier.amount * effect.multiplier) -
+                modifier.amount,
+            },
+          });
+        }
+        break;
+      }
+      case "perform": {
+        if (effect.score) {
+          diffs = [
+            ...diffs,
+            ...calculatePerformingScoreEffect(
+              lesson.idol,
+              remainingIncrementableScore,
+              effect.score,
+            ),
+          ];
+        }
+        if (effect.vitality) {
+          diffs = [
+            ...diffs,
+            calculatePerformingVitalityEffect(lesson.idol, effect.vitality),
+          ];
+        }
+        break;
+      }
+      case "performLeveragingModifier": {
+        let score = 0;
+        const modifierKind = effect.modifierKind;
+        switch (modifierKind) {
+          case "motivation": {
+            const motivation = lesson.idol.modifiers.find(
+              (e) => e.kind === "motivation",
+            );
+            const motivationAmount =
+              motivation && "amount" in motivation ? motivation.amount : 0;
+            score = Math.ceil((motivationAmount * effect.percentage) / 100);
+            break;
+          }
+          case "positiveImpression": {
+            const positiveImpression = lesson.idol.modifiers.find(
+              (e) => e.kind === "positiveImpression",
+            );
+            const positiveImpressionAmount =
+              positiveImpression && "amount" in positiveImpression
+                ? positiveImpression.amount
+                : 0;
+            score = Math.ceil(
+              (positiveImpressionAmount * effect.percentage) / 100,
+            );
+            break;
+          }
+          default: {
+            const unreachable: never = modifierKind;
+            throw new Error(`Unreachable statement`);
+          }
+        }
+        diffs.push({
+          kind: "score",
+          actual:
+            remainingIncrementableScore !== undefined
+              ? Math.min(score, remainingIncrementableScore)
+              : score,
+          max: score,
+        });
+        break;
+      }
+      case "performLeveragingVitality": {
+        // 本家のインタラクションや効果説明上、先に元気を減少させる
+        if (effect.reductionKind !== undefined) {
+          const reductionRate = effect.reductionKind === "zero" ? 1.0 : 0.5;
+          const value = Math.floor(lesson.idol.vitality * reductionRate);
+          diffs.push({
+            kind: "vitality",
+            actual: -value,
+            max: -value,
+          });
+        }
+        const score = Math.ceil(
+          (lesson.idol.vitality * effect.percentage) / 100,
+        );
+        diffs.push({
+          kind: "score",
+          actual:
+            remainingIncrementableScore !== undefined
+              ? Math.min(score, remainingIncrementableScore)
+              : score,
+          max: score,
+        });
+        break;
+      }
+      case "recoverLife": {
+        diffs.push({
+          kind: "life",
+          actual: Math.min(
+            effect.value,
+            lesson.idol.original.maxLife - lesson.idol.life,
+          ),
+          max: effect.value,
+        });
+        break;
+      }
+      default: {
+        const unreachable: never = effectKind;
+        throw new Error(`Unreachable statement`);
+      }
+    }
+  }
+  return diffs;
+};
+
+/**
+ * スキルカードを使用する
+ */
+export const useCard = (
+  lesson: Lesson,
+  historyResultIndex: LessonUpdateQuery["reason"]["historyResultIndex"],
+  params: {
+    getRandom: GetRandom;
+    idGenerator: IdGenerator;
+    selectedCardInHandIndex: number;
+  },
+): LessonMutationResult => {
+  const cardId = lesson.hand[params.selectedCardInHandIndex];
+  if (cardId === undefined) {
+    throw new Error(
+      `Card not found in hand: selectedCardInHandIndex=${params.selectedCardInHandIndex}`,
+    );
+  }
+  const card = lesson.cards.find((card) => card.id === cardId);
+  if (card === undefined) {
+    throw new Error(`Card not found in cards: cardId=${cardId}`);
+  }
+  const cardContent = getCardContentDefinition(card);
+  const hasDoubleEffect =
+    lesson.idol.modifiers.find((e) => e.kind === "doubleEffect") !== undefined;
+  let newLesson = lesson;
+  let nextHistoryResultIndex = historyResultIndex;
+
+  //
+  // 使用可否のバリデーション
+  //
+  // - 本関数は、使用条件を満たさないスキルカードに対しては使えない前提
+  //
+  if (!canUseCard(lesson, cardContent.cost, cardContent.condition)) {
+    throw new Error(`Can not use the card: ${card.original.definition.name}`);
+  }
+
+  //
+  // 使用した手札を捨札か除外へ移動
+  //
+  const discardOrRemovedCardUpdates: LessonUpdateQuery[] = [
+    {
+      ...createCardPlacementDiff(
+        {
+          hand: lesson.hand,
+          discardPile: lesson.discardPile,
+          removedCardPile: lesson.removedCardPile,
+        },
+        {
+          hand: newLesson.hand.filter((id) => id !== cardId),
+          ...(cardContent.usableOncePerLesson
+            ? { removedCardPile: [...newLesson.removedCardPile, cardId] }
+            : { discardPile: [...newLesson.discardPile, cardId] }),
+        },
+      ),
+      reason: {
+        kind: "cardUsage",
+        cardId,
+        historyTurnNumber: newLesson.turnNumber,
+        historyResultIndex: nextHistoryResultIndex,
+      },
+    },
+  ];
+  newLesson = patchUpdates(newLesson, discardOrRemovedCardUpdates);
+  nextHistoryResultIndex++;
+
+  //
+  // コスト消費
+  //
+  const costConsumptionUpdates: LessonUpdateQuery[] = calculateCostConsumption(
+    newLesson.idol,
+    calculateActualActionCost(cardContent.cost, newLesson.idol.modifiers),
+  ).map((diff) => ({
+    ...diff,
+    reason: {
+      kind: "cardUsage",
+      cardId: card.id,
+      historyTurnNumber: newLesson.turnNumber,
+      historyResultIndex: nextHistoryResultIndex,
+    },
+  }));
+  newLesson = patchUpdates(newLesson, costConsumptionUpdates);
+  nextHistoryResultIndex++;
+
+  //
+  // 副作用を含む効果発動を1-2回行う
+  //
+  let effectActivationUpdates: LessonUpdateQuery[] = [];
+  for (let times = 1; times <= (hasDoubleEffect ? 2 : 1); times++) {
+    //
+    // 主効果発動
+    //
+    let effectActivationUpdatesOnce: LessonUpdateQuery[] = computeEffects(
+      newLesson,
+      cardContent.effects,
+      params.getRandom,
+      params.idGenerator,
+    ).map((diff) => ({
+      ...diff,
+      reason: {
+        kind: "cardUsage",
+        cardId: card.id,
+        historyTurnNumber: newLesson.turnNumber,
+        historyResultIndex: nextHistoryResultIndex,
+      },
+    }));
+
+    //
+    // 「次に使用するスキルカードの効果をもう1回発動」を消費
+    //
+    if (hasDoubleEffect && times === 1) {
+      effectActivationUpdatesOnce = [
+        ...effectActivationUpdatesOnce,
+        createLessonUpdateQueryFromDiff(
+          {
+            kind: "modifier",
+            modifier: {
+              kind: "doubleEffect",
+              times: 1,
+            },
+          },
+          {
+            kind: "cardUsage",
+            cardId: card.id,
+            historyTurnNumber: newLesson.turnNumber,
+            historyResultIndex: nextHistoryResultIndex,
+          },
+        ),
+      ];
+    }
+
+    //
+    // 状態修正によるスキルカード使用毎効果発動
+    //
+    const effectsUponCardUsage = newLesson.idol.modifiers.filter(
+      (e) =>
+        e.kind === "effectActivationUponCardUsage" &&
+        e.cardKind === card.original.definition.cardSummaryKind,
+    ) as Array<Extract<Modifier, { kind: "effectActivationUponCardUsage" }>>;
+    for (const { effect } of effectsUponCardUsage) {
+      effectActivationUpdatesOnce = [
+        ...effectActivationUpdatesOnce,
+        ...computeEffects(
+          newLesson,
+          [effect],
+          params.getRandom,
+          params.idGenerator,
+        ).map((diff) =>
+          createLessonUpdateQueryFromDiff(diff, {
+            kind: "cardUsageTrigger",
+            cardId: card.id,
+            historyTurnNumber: newLesson.turnNumber,
+            historyResultIndex: nextHistoryResultIndex,
+          }),
+        ),
+      ];
+    }
+
+    //
+    // TODO: Pアイテムのスキルカード使用時に効果発動
+    //
+
+    //
+    // TODO: Pアイテムのスキルカード使用による状態修正増加時トリガー
+    //
+
+    // 1回分のスキルカード使用に対する副作用を含んで完了してから、1ループに1回のみレッスンの状態を更新する
+    // 例えば、「ファンシーチャーム」は「以降、メンタルスキルカード使用時、好印象+1」の効果だが、自身の使用によって発動はしないことを担保する必要がある
+    newLesson = patchUpdates(newLesson, effectActivationUpdatesOnce);
+    effectActivationUpdates = [
+      ...effectActivationUpdates,
+      ...effectActivationUpdatesOnce,
+    ];
+  }
+  // スキルカード追加発動時は、スキルカード1枚分の結果の中に表示されている
+  nextHistoryResultIndex++;
+
+  return {
+    nextHistoryResultIndex,
+    updates: [
+      ...discardOrRemovedCardUpdates,
+      ...costConsumptionUpdates,
+      ...effectActivationUpdates,
+    ],
+  };
+};

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -1,0 +1,1081 @@
+import { Card, Idol, IdolInProduction, Lesson, Modifier } from "./types";
+import { getCardDataById } from "./data/card";
+import { getIdolDataById } from "./data/idol";
+import { getProducerItemDataById } from "./data/producer-item";
+import {
+  calculateActualActionCost,
+  calculateClearScoreProgress,
+  createIdolInProduction,
+  createLessonGamePlay,
+  patchUpdates,
+  prepareCardsForLesson,
+} from "./models";
+import { createIdGenerator } from "./utils";
+
+const createCardsForTest = (ids: Array<Card["id"]>): Card[] => {
+  return prepareCardsForLesson(
+    ids.map((id) => ({
+      id,
+      definition: getCardDataById("apirunokihon"),
+      enhanced: false,
+      enabled: true,
+    })),
+  );
+};
+
+describe("createIdolInProduction", () => {
+  test("it creates an idol in production", () => {
+    const idGenerator = createIdGenerator();
+    const idolInProduction = createIdolInProduction({
+      idolDefinitionId: "hanamisaki-r-1",
+      cards: [
+        {
+          id: idGenerator(),
+          definition: getCardDataById("apirunokihon"),
+          enhanced: false,
+          enabled: true,
+        },
+      ],
+      specificCardEnhanced: false,
+      specificProducerItemEnhanced: false,
+      idGenerator,
+    });
+    expect(idolInProduction).toStrictEqual({
+      deck: [
+        {
+          id: "2",
+          definition: getCardDataById("shinshinkiei"),
+          enhanced: false,
+          enabled: true,
+        },
+        {
+          id: "1",
+          definition: getCardDataById("apirunokihon"),
+          enhanced: false,
+          enabled: true,
+        },
+      ],
+      definition: getIdolDataById("hanamisaki-r-1"),
+      life: 32,
+      maxLife: 32,
+      producerItems: [
+        {
+          id: "3",
+          definition: getProducerItemDataById("bakuonraion"),
+          enhanced: false,
+        },
+      ],
+    });
+  });
+});
+describe("calculateClearScoreProgress", () => {
+  const testCases: Array<{
+    args: Parameters<typeof calculateClearScoreProgress>;
+    expected: ReturnType<typeof calculateClearScoreProgress>;
+  }> = [
+    {
+      args: [0, { clear: 100 }],
+      expected: {
+        necessaryClearScore: 100,
+        necessaryPerfectScore: undefined,
+        remainingClearScore: 100,
+        remainingPerfectScore: undefined,
+        clearScoreProgressPercentage: 0,
+      },
+    },
+    {
+      args: [10, { clear: 1000 }],
+      expected: {
+        necessaryClearScore: 1000,
+        necessaryPerfectScore: undefined,
+        remainingClearScore: 990,
+        remainingPerfectScore: undefined,
+        clearScoreProgressPercentage: 1,
+      },
+    },
+    {
+      args: [9, { clear: 1000 }],
+      expected: {
+        necessaryClearScore: 1000,
+        necessaryPerfectScore: undefined,
+        remainingClearScore: 991,
+        remainingPerfectScore: undefined,
+        clearScoreProgressPercentage: 0,
+      },
+    },
+    {
+      args: [50, { clear: 100, perfect: 300 }],
+      expected: {
+        necessaryClearScore: 100,
+        necessaryPerfectScore: 300,
+        remainingClearScore: 50,
+        remainingPerfectScore: 250,
+        clearScoreProgressPercentage: 50,
+      },
+    },
+  ];
+  test.each(testCases)(
+    "$args.0, $args.1 => $expected",
+    ({ args, expected }) => {
+      expect(calculateClearScoreProgress(...args)).toStrictEqual(expected);
+    },
+  );
+});
+describe("createLessonGamePlay", () => {
+  test("it creates a lesson game play", () => {
+    const idGenerator = createIdGenerator();
+    const idolInProduction = createIdolInProduction({
+      idolDefinitionId: "hanamisaki-r-1",
+      cards: [
+        {
+          id: idGenerator(),
+          definition: getCardDataById("apirunokihon"),
+          enhanced: false,
+          enabled: true,
+        },
+        {
+          id: idGenerator(),
+          definition: getCardDataById("pozunokihon"),
+          enhanced: false,
+          enabled: true,
+        },
+      ],
+      specificCardEnhanced: false,
+      specificProducerItemEnhanced: false,
+      idGenerator,
+    });
+    const lessonGamePlay = createLessonGamePlay({
+      idolInProduction,
+      lastTurnNumber: 6,
+    });
+    expect(lessonGamePlay).toStrictEqual({
+      getRandom: expect.any(Function),
+      idGenerator: expect.any(Function),
+      initialLesson: {
+        clearScoreThresholds: undefined,
+        idol: {
+          original: idolInProduction,
+          life: 32,
+          vitality: 0,
+          modifiers: [],
+          totalCardUsageCount: 0,
+        },
+        cards: expect.any(Array),
+        hand: [],
+        deck: expect.any(Array),
+        discardPile: [],
+        removedCardPile: [],
+        selectedCardInHandIndex: undefined,
+        score: 0,
+        turnNumber: 1,
+        lastTurnNumber: 6,
+        remainingTurns: 0,
+      },
+      updates: [],
+    });
+  });
+});
+describe("calculateActualActionCost", () => {
+  const testCases: Array<{
+    args: Parameters<typeof calculateActualActionCost>;
+    expected: ReturnType<typeof calculateActualActionCost>;
+  }> = [
+    {
+      args: [{ kind: "normal", value: 1 }, []],
+      expected: { kind: "normal", value: 1 },
+    },
+    {
+      args: [
+        { kind: "normal", value: 1 },
+        [{ kind: "lifeConsumptionReduction", value: 2 }],
+      ],
+      expected: { kind: "normal", value: 0 },
+    },
+    {
+      args: [
+        { kind: "normal", value: 2 },
+        [{ kind: "halfLifeConsumption", duration: 1 }],
+      ],
+      expected: { kind: "normal", value: 1 },
+    },
+    {
+      args: [
+        { kind: "normal", value: 3 },
+        [{ kind: "halfLifeConsumption", duration: 1 }],
+      ],
+      expected: { kind: "normal", value: 2 },
+    },
+    {
+      args: [
+        { kind: "normal", value: 1 },
+        [{ kind: "doubleLifeConsumption", duration: 1 }],
+      ],
+      expected: { kind: "normal", value: 2 },
+    },
+    {
+      args: [
+        { kind: "normal", value: 2 },
+        [
+          { kind: "halfLifeConsumption", duration: 1 },
+          { kind: "doubleLifeConsumption", duration: 1 },
+        ],
+      ],
+      expected: { kind: "normal", value: 2 },
+    },
+    {
+      args: [
+        { kind: "normal", value: 2 },
+        [
+          { kind: "lifeConsumptionReduction", value: 1 },
+          { kind: "halfLifeConsumption", duration: 1 },
+          { kind: "doubleLifeConsumption", duration: 1 },
+        ],
+      ],
+      expected: { kind: "normal", value: 1 },
+    },
+    {
+      args: [
+        { kind: "life", value: 1 },
+        [{ kind: "lifeConsumptionReduction", value: 1 }],
+      ],
+      expected: { kind: "life", value: 0 },
+    },
+    {
+      args: [
+        { kind: "focus", value: 1 },
+        [{ kind: "lifeConsumptionReduction", value: 1 }],
+      ],
+      expected: { kind: "focus", value: 1 },
+    },
+    {
+      args: [
+        { kind: "goodCondition", value: 1 },
+        [{ kind: "lifeConsumptionReduction", value: 1 }],
+      ],
+      expected: { kind: "goodCondition", value: 1 },
+    },
+    {
+      args: [
+        { kind: "motivation", value: 1 },
+        [{ kind: "lifeConsumptionReduction", value: 1 }],
+      ],
+      expected: { kind: "motivation", value: 1 },
+    },
+    {
+      args: [
+        { kind: "positiveImpression", value: 1 },
+        [{ kind: "lifeConsumptionReduction", value: 1 }],
+      ],
+      expected: { kind: "positiveImpression", value: 1 },
+    },
+  ];
+  test.each(testCases)(
+    "$args.0, [$args.1.0, $args.1.1, $args.1.2] => $expected",
+    ({ args, expected }) => {
+      expect(calculateActualActionCost(...args)).toStrictEqual(expected);
+    },
+  );
+});
+describe("patchUpdates", () => {
+  describe("cardEnhancement", () => {
+    test("it works", () => {
+      const lessonMock = {
+        cards: [
+          {
+            id: "1",
+            enhancements: [] as Card["enhancements"],
+          },
+          {
+            id: "2",
+            enhancements: [] as Card["enhancements"],
+          },
+        ],
+      } as Lesson;
+      const lesson = patchUpdates(lessonMock, [
+        {
+          kind: "cardEnhancement",
+          cardIds: ["1"],
+          reason: {
+            kind: "lessonStartTrigger",
+            historyTurnNumber: 1,
+            historyResultIndex: 1,
+          },
+        },
+      ]);
+      expect(lesson.cards[0].enhancements).toStrictEqual([{ kind: "effect" }]);
+      expect(lesson.cards[1].enhancements).toStrictEqual([]);
+    });
+  });
+  describe("cardPlacement", () => {
+    test("全てのプロパティが存在する", () => {
+      const lessonMock = {
+        deck: ["1"],
+        discardPile: ["2"],
+        hand: ["3"],
+        removedCardPile: ["4"],
+      } as Lesson;
+      const lesson = patchUpdates(lessonMock, [
+        {
+          kind: "cardPlacement",
+          deck: ["11", "111"],
+          discardPile: ["22", "222"],
+          hand: ["33", "333"],
+          removedCardPile: ["44", "444"],
+          reason: {
+            kind: "lessonStartTrigger",
+            historyTurnNumber: 1,
+            historyResultIndex: 1,
+          },
+        },
+      ]);
+      expect(lesson.deck).toStrictEqual(["11", "111"]);
+      expect(lesson.discardPile).toStrictEqual(["22", "222"]);
+      expect(lesson.hand).toStrictEqual(["33", "333"]);
+      expect(lesson.removedCardPile).toStrictEqual(["44", "444"]);
+    });
+    test("deckとdiscardPileのみ", () => {
+      const lessonMock = {
+        deck: ["1"],
+        discardPile: ["2"],
+        hand: ["3"],
+        removedCardPile: ["4"],
+      } as Lesson;
+      const lesson = patchUpdates(lessonMock, [
+        {
+          kind: "cardPlacement",
+          deck: ["11", "111"],
+          discardPile: ["22", "222"],
+          reason: {
+            kind: "lessonStartTrigger",
+            historyTurnNumber: 1,
+            historyResultIndex: 1,
+          },
+        },
+      ]);
+      expect(lesson.deck).toStrictEqual(["11", "111"]);
+      expect(lesson.discardPile).toStrictEqual(["22", "222"]);
+      expect(lesson.hand).toStrictEqual(["3"]);
+      expect(lesson.removedCardPile).toStrictEqual(["4"]);
+    });
+    test("handとremovedCardPileのみ", () => {
+      const lessonMock = {
+        deck: ["1"],
+        discardPile: ["2"],
+        hand: ["3"],
+        removedCardPile: ["4"],
+      } as Lesson;
+      const lesson = patchUpdates(lessonMock, [
+        {
+          kind: "cardPlacement",
+          hand: ["33", "333"],
+          removedCardPile: ["44", "444"],
+          reason: {
+            kind: "lessonStartTrigger",
+            historyTurnNumber: 1,
+            historyResultIndex: 1,
+          },
+        },
+      ]);
+      expect(lesson.deck).toStrictEqual(["1"]);
+      expect(lesson.discardPile).toStrictEqual(["2"]);
+      expect(lesson.hand).toStrictEqual(["33", "333"]);
+      expect(lesson.removedCardPile).toStrictEqual(["44", "444"]);
+    });
+  });
+  describe("cards", () => {
+    test("it works", () => {
+      const lessonMock = {
+        cards: [
+          {
+            id: "1",
+          },
+          {
+            id: "2",
+          },
+        ],
+      } as Lesson;
+      const lesson = patchUpdates(lessonMock, [
+        {
+          kind: "cards",
+          cards: [],
+          reason: {
+            kind: "lessonStartTrigger",
+            historyTurnNumber: 1,
+            historyResultIndex: 1,
+          },
+        },
+      ]);
+      expect(lesson.cards).toStrictEqual([]);
+    });
+  });
+  describe("modifier", () => {
+    describe("新規追加", () => {
+      test("同種の状態修正が存在しない時、末尾へ新規追加する", () => {
+        let lessonMock = {
+          idol: {
+            modifiers: [
+              {
+                kind: "focus",
+                amount: 1,
+              },
+            ],
+          },
+        } as Lesson;
+        lessonMock = patchUpdates(lessonMock, [
+          {
+            kind: "modifier",
+            modifier: {
+              kind: "goodCondition",
+              duration: 2,
+            },
+            reason: {
+              kind: "lessonStartTrigger",
+              historyTurnNumber: 1,
+              historyResultIndex: 1,
+            },
+          },
+        ]);
+        expect(lessonMock.idol.modifiers).toStrictEqual([
+          {
+            kind: "focus",
+            amount: 1,
+          },
+          {
+            kind: "goodCondition",
+            duration: 2,
+          },
+        ]);
+      });
+      test("一部の状態修正は、同種のものが存在しても新規追加する", () => {
+        let lessonMock = {
+          idol: {
+            modifiers: [
+              {
+                kind: "delayedEffect",
+              },
+            ],
+          },
+        } as Lesson;
+        lessonMock = patchUpdates(lessonMock, [
+          {
+            kind: "modifier",
+            modifier: {
+              kind: "delayedEffect",
+            } as Extract<Modifier, { kind: "delayedEffect" }>,
+            reason: {
+              kind: "lessonStartTrigger",
+              historyTurnNumber: 1,
+              historyResultIndex: 1,
+            },
+          },
+        ]);
+        expect(lessonMock.idol.modifiers).toStrictEqual([
+          {
+            kind: "delayedEffect",
+          },
+          {
+            kind: "delayedEffect",
+          },
+        ]);
+      });
+    });
+    describe("増減対象のプロパティがamountのものの合算", () => {
+      const modifierKinds = [
+        "focus",
+        "motivation",
+        "positiveImpression",
+      ] as const;
+      for (const modifierKind of modifierKinds) {
+        describe(modifierKind, () => {
+          test("増加する", () => {
+            let lessonMock = {
+              idol: {
+                modifiers: [
+                  {
+                    kind: modifierKind,
+                    amount: 1,
+                  },
+                ],
+              },
+            } as Lesson;
+            lessonMock = patchUpdates(lessonMock, [
+              {
+                kind: "modifier",
+                modifier: {
+                  kind: modifierKind,
+                  amount: 2,
+                },
+                reason: {
+                  kind: "lessonStartTrigger",
+                  historyTurnNumber: 1,
+                  historyResultIndex: 1,
+                },
+              },
+            ]);
+            expect(lessonMock.idol.modifiers).toStrictEqual([
+              {
+                kind: modifierKind,
+                amount: 3,
+              },
+            ]);
+          });
+          test("減少する", () => {
+            let lessonMock = {
+              idol: {
+                modifiers: [
+                  {
+                    kind: modifierKind,
+                    amount: 5,
+                  },
+                ],
+              },
+            } as Lesson;
+            lessonMock = patchUpdates(lessonMock, [
+              {
+                kind: "modifier",
+                modifier: {
+                  kind: modifierKind,
+                  amount: -1,
+                },
+                reason: {
+                  kind: "lessonStartTrigger",
+                  historyTurnNumber: 1,
+                  historyResultIndex: 1,
+                },
+              },
+            ]);
+            expect(lessonMock.idol.modifiers).toStrictEqual([
+              {
+                kind: modifierKind,
+                amount: 4,
+              },
+            ]);
+          });
+          test("減少した結果0になった時、削除する", () => {
+            let lessonMock = {
+              idol: {
+                modifiers: [
+                  {
+                    kind: modifierKind,
+                    amount: 5,
+                  },
+                ],
+              },
+            } as Lesson;
+            lessonMock = patchUpdates(lessonMock, [
+              {
+                kind: "modifier",
+                modifier: {
+                  kind: modifierKind,
+                  amount: -5,
+                },
+                reason: {
+                  kind: "lessonStartTrigger",
+                  historyTurnNumber: 1,
+                  historyResultIndex: 1,
+                },
+              },
+            ]);
+            expect(lessonMock.idol.modifiers).toStrictEqual([]);
+          });
+        });
+      }
+    });
+    describe("増減対象のプロパティがdurationのものの合算", () => {
+      const modifierKinds = ["excellentCondition", "goodCondition"] as const;
+      for (const modifierKind of modifierKinds) {
+        describe(modifierKind, () => {
+          test("増加する", () => {
+            let lessonMock = {
+              idol: {
+                modifiers: [
+                  {
+                    kind: modifierKind,
+                    duration: 1,
+                  },
+                ],
+              },
+            } as Lesson;
+            lessonMock = patchUpdates(lessonMock, [
+              {
+                kind: "modifier",
+                modifier: {
+                  kind: modifierKind,
+                  duration: 2,
+                },
+                reason: {
+                  kind: "lessonStartTrigger",
+                  historyTurnNumber: 1,
+                  historyResultIndex: 1,
+                },
+              },
+            ]);
+            expect(lessonMock.idol.modifiers).toStrictEqual([
+              {
+                kind: modifierKind,
+                duration: 3,
+              },
+            ]);
+          });
+          test("減少する", () => {
+            let lessonMock = {
+              idol: {
+                modifiers: [
+                  {
+                    kind: modifierKind,
+                    duration: 5,
+                  },
+                ],
+              },
+            } as Lesson;
+            lessonMock = patchUpdates(lessonMock, [
+              {
+                kind: "modifier",
+                modifier: {
+                  kind: modifierKind,
+                  duration: -1,
+                },
+                reason: {
+                  kind: "lessonStartTrigger",
+                  historyTurnNumber: 1,
+                  historyResultIndex: 1,
+                },
+              },
+            ]);
+            expect(lessonMock.idol.modifiers).toStrictEqual([
+              {
+                kind: modifierKind,
+                duration: 4,
+              },
+            ]);
+          });
+          test("減少した結果0になった時、削除する", () => {
+            let lessonMock = {
+              idol: {
+                modifiers: [
+                  {
+                    kind: modifierKind,
+                    duration: 5,
+                  },
+                ],
+              },
+            } as Lesson;
+            lessonMock = patchUpdates(lessonMock, [
+              {
+                kind: "modifier",
+                modifier: {
+                  kind: modifierKind,
+                  duration: -5,
+                },
+                reason: {
+                  kind: "lessonStartTrigger",
+                  historyTurnNumber: 1,
+                  historyResultIndex: 1,
+                },
+              },
+            ]);
+            expect(lessonMock.idol.modifiers).toStrictEqual([]);
+          });
+        });
+      }
+    });
+    describe("増減対象のプロパティがtimesのものの合算", () => {
+      const modifierKinds = ["debuffProtection"] as const;
+      for (const modifierKind of modifierKinds) {
+        describe(modifierKind, () => {
+          test("増加する", () => {
+            let lessonMock = {
+              idol: {
+                modifiers: [
+                  {
+                    kind: modifierKind,
+                    times: 1,
+                  },
+                ],
+              },
+            } as Lesson;
+            lessonMock = patchUpdates(lessonMock, [
+              {
+                kind: "modifier",
+                modifier: {
+                  kind: modifierKind,
+                  times: 2,
+                },
+                reason: {
+                  kind: "lessonStartTrigger",
+                  historyTurnNumber: 1,
+                  historyResultIndex: 1,
+                },
+              },
+            ]);
+            expect(lessonMock.idol.modifiers).toStrictEqual([
+              {
+                kind: modifierKind,
+                times: 3,
+              },
+            ]);
+          });
+          test("減少する", () => {
+            let lessonMock = {
+              idol: {
+                modifiers: [
+                  {
+                    kind: modifierKind,
+                    times: 5,
+                  },
+                ],
+              },
+            } as Lesson;
+            lessonMock = patchUpdates(lessonMock, [
+              {
+                kind: "modifier",
+                modifier: {
+                  kind: modifierKind,
+                  times: -1,
+                },
+                reason: {
+                  kind: "lessonStartTrigger",
+                  historyTurnNumber: 1,
+                  historyResultIndex: 1,
+                },
+              },
+            ]);
+            expect(lessonMock.idol.modifiers).toStrictEqual([
+              {
+                kind: modifierKind,
+                times: 4,
+              },
+            ]);
+          });
+          test("減少した結果0になった時、削除する", () => {
+            let lessonMock = {
+              idol: {
+                modifiers: [
+                  {
+                    kind: modifierKind,
+                    times: 5,
+                  },
+                ],
+              },
+            } as Lesson;
+            lessonMock = patchUpdates(lessonMock, [
+              {
+                kind: "modifier",
+                modifier: {
+                  kind: modifierKind,
+                  times: -5,
+                },
+                reason: {
+                  kind: "lessonStartTrigger",
+                  historyTurnNumber: 1,
+                  historyResultIndex: 1,
+                },
+              },
+            ]);
+            expect(lessonMock.idol.modifiers).toStrictEqual([]);
+          });
+        });
+      }
+    });
+    describe("増減対象のプロパティがvalueのものの合算", () => {
+      const modifierKinds = ["lifeConsumptionReduction"] as const;
+      for (const modifierKind of modifierKinds) {
+        describe(modifierKind, () => {
+          test("増加する", () => {
+            let lessonMock = {
+              idol: {
+                modifiers: [
+                  {
+                    kind: modifierKind,
+                    value: 1,
+                  },
+                ],
+              },
+            } as Lesson;
+            lessonMock = patchUpdates(lessonMock, [
+              {
+                kind: "modifier",
+                modifier: {
+                  kind: modifierKind,
+                  value: 2,
+                },
+                reason: {
+                  kind: "lessonStartTrigger",
+                  historyTurnNumber: 1,
+                  historyResultIndex: 1,
+                },
+              },
+            ]);
+            expect(lessonMock.idol.modifiers).toStrictEqual([
+              {
+                kind: modifierKind,
+                value: 3,
+              },
+            ]);
+          });
+          test("減少する", () => {
+            let lessonMock = {
+              idol: {
+                modifiers: [
+                  {
+                    kind: modifierKind,
+                    value: 5,
+                  },
+                ],
+              },
+            } as Lesson;
+            lessonMock = patchUpdates(lessonMock, [
+              {
+                kind: "modifier",
+                modifier: {
+                  kind: modifierKind,
+                  value: -1,
+                },
+                reason: {
+                  kind: "lessonStartTrigger",
+                  historyTurnNumber: 1,
+                  historyResultIndex: 1,
+                },
+              },
+            ]);
+            expect(lessonMock.idol.modifiers).toStrictEqual([
+              {
+                kind: modifierKind,
+                value: 4,
+              },
+            ]);
+          });
+          test("減少した結果0になった時、削除する", () => {
+            let lessonMock = {
+              idol: {
+                modifiers: [
+                  {
+                    kind: modifierKind,
+                    value: 5,
+                  },
+                ],
+              },
+            } as Lesson;
+            lessonMock = patchUpdates(lessonMock, [
+              {
+                kind: "modifier",
+                modifier: {
+                  kind: modifierKind,
+                  value: -5,
+                },
+                reason: {
+                  kind: "lessonStartTrigger",
+                  historyTurnNumber: 1,
+                  historyResultIndex: 1,
+                },
+              },
+            ]);
+            expect(lessonMock.idol.modifiers).toStrictEqual([]);
+          });
+        });
+      }
+    });
+    describe("doubleEffect", () => {
+      test("既存レコードへ1レコード足したとき、合算されずに2レコードになる", () => {
+        let lessonMock = {
+          idol: {
+            modifiers: [
+              {
+                kind: "doubleEffect",
+                times: 1,
+              },
+            ],
+          },
+        } as Lesson;
+        lessonMock = patchUpdates(lessonMock, [
+          {
+            kind: "modifier",
+            modifier: {
+              kind: "doubleEffect",
+              times: 1,
+            },
+            reason: {
+              kind: "lessonStartTrigger",
+              historyTurnNumber: 1,
+              historyResultIndex: 1,
+            },
+          },
+        ]);
+        expect(lessonMock.idol.modifiers).toStrictEqual([
+          {
+            kind: "doubleEffect",
+            times: 1,
+          },
+          {
+            kind: "doubleEffect",
+            times: 1,
+          },
+        ]);
+      });
+      test("削除更新を受け取った時、先頭の1レコードのみが削除される", () => {
+        let lessonMock = {
+          idol: {
+            modifiers: [
+              {
+                kind: "doubleEffect",
+                times: 1,
+              },
+              {
+                kind: "focus",
+                amount: 1,
+              },
+              {
+                kind: "doubleEffect",
+                times: 1,
+              },
+            ],
+          },
+        } as Lesson;
+        lessonMock = patchUpdates(lessonMock, [
+          {
+            kind: "modifier",
+            modifier: {
+              kind: "doubleEffect",
+              times: -1,
+            },
+            reason: {
+              kind: "lessonStartTrigger",
+              historyTurnNumber: 1,
+              historyResultIndex: 1,
+            },
+          },
+        ]);
+        expect(lessonMock.idol.modifiers).toStrictEqual([
+          {
+            kind: "focus",
+            amount: 1,
+          },
+          {
+            kind: "doubleEffect",
+            times: 1,
+          },
+        ]);
+      });
+    });
+  });
+  describe("life", () => {
+    test("it works", () => {
+      let lessonMock = {
+        idol: {
+          life: 5,
+        },
+      } as Lesson;
+      lessonMock = patchUpdates(lessonMock, [
+        {
+          kind: "life",
+          actual: -2,
+          max: -3,
+          reason: {
+            kind: "lessonStartTrigger",
+            historyTurnNumber: 1,
+            historyResultIndex: 1,
+          },
+        },
+      ]);
+      expect(lessonMock.idol.life).toBe(3);
+    });
+  });
+  describe("remainingTurns", () => {
+    test("it works", () => {
+      let lessonMock = {
+        remainingTurns: 0,
+      } as Lesson;
+      lessonMock = patchUpdates(lessonMock, [
+        {
+          kind: "remainingTurns",
+          amount: 1,
+          reason: {
+            kind: "lessonStartTrigger",
+            historyTurnNumber: 1,
+            historyResultIndex: 1,
+          },
+        },
+      ]);
+      expect(lessonMock.remainingTurns).toBe(1);
+    });
+  });
+  describe("selectedCardInHandIndex", () => {
+    test("it works", () => {
+      const lessonMock = {
+        selectedCardInHandIndex: undefined,
+      } as Lesson;
+      const lesson = patchUpdates(lessonMock, [
+        {
+          kind: "selectedCardInHandIndex",
+          index: 1,
+          reason: {
+            kind: "lessonStartTrigger",
+            historyTurnNumber: 1,
+            historyResultIndex: 1,
+          },
+        },
+      ]);
+      expect(lesson.selectedCardInHandIndex).toBe(1);
+    });
+  });
+  describe("score", () => {
+    test("it works", () => {
+      let lessonMock = {
+        score: 1,
+      } as Lesson;
+      lessonMock = patchUpdates(lessonMock, [
+        {
+          kind: "score",
+          actual: 2,
+          max: 3,
+          reason: {
+            kind: "lessonStartTrigger",
+            historyTurnNumber: 1,
+            historyResultIndex: 1,
+          },
+        },
+      ]);
+      expect(lessonMock.score).toBe(3);
+    });
+  });
+  describe("turnNumberIncrease", () => {
+    test("it works", () => {
+      let lessonMock = {
+        turnNumber: 0,
+      } as Lesson;
+      lessonMock = patchUpdates(lessonMock, [
+        {
+          kind: "turnNumberIncrease",
+          reason: {
+            kind: "lessonStartTrigger",
+            historyTurnNumber: 1,
+            historyResultIndex: 1,
+          },
+        },
+      ]);
+      expect(lessonMock.turnNumber).toBe(1);
+    });
+  });
+  describe("vitality", () => {
+    test("it works", () => {
+      let lessonMock = {
+        idol: {
+          vitality: 5,
+        },
+      } as Lesson;
+      lessonMock = patchUpdates(lessonMock, [
+        {
+          kind: "vitality",
+          actual: -2,
+          max: -3,
+          reason: {
+            kind: "lessonStartTrigger",
+            historyTurnNumber: 1,
+            historyResultIndex: 1,
+          },
+        },
+      ]);
+      expect(lessonMock.idol.vitality).toBe(3);
+    });
+  });
+});

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,0 +1,446 @@
+// このコメントブロックは、主にCopilotに対する指示を記述するためのものである。
+//
+// - このファイル及び関連するファイル群は、ある既存のデッキ構築型カードバトルローグライトゲームのコアライブラリである。
+// - ライブラリ名もしくはプロジェクト名は、"gakumasu-core"である。
+// - このファイルは、npm packageのエントリーポイントである。
+// - UIに関する実装は行わない。
+// - TypeScriptの型のプロパティ名を列挙する際は、キャメルケースを使い、アルファベット降順に並べる。
+// - TypeScriptの型でstringのUnion型を列挙する際は、アルファベット降順に並べる。
+// - MUST: ソースコードのコメント内では、Copilotは**絶対に**提案や補完を行わないこと。
+
+// TODO: Pドリンク
+// TODO: サポートアビリティ
+// TODO: レッスン内の応援/トラブル
+// TODO: レッスン履歴
+// TODO: データの永続化サポート
+// TODO: コンテスト、後のためのメモ
+//       - AIの挙動を解読する必要がある、多少眺めた限りだとわからなかった
+//       - レッスン中に放置するとカードがうっすら光っておすすめカードを教えてくれるが、それがコンテストと同じAIかもしれない
+//         - もしそうだとすると、AIはサーバ側ではなくてクライアント側が計算しているのかもしれない
+
+import { getCardDataById } from "./data/card";
+import { getCharacterDataById } from "./data/character";
+import { getIdolDataById } from "./data/idol";
+import { getProducerItemDataById } from "./data/producer-item";
+import {
+  ActionCost,
+  Card,
+  CardInProduction,
+  GetRandom,
+  IdGenerator,
+  Idol,
+  IdolInProduction,
+  Lesson,
+  LessonGamePlay,
+  LessonUpdateQuery,
+  LessonUpdateQueryDiff,
+  Modifier,
+} from "./types";
+import { createIdGenerator, shuffleArray } from "./utils";
+
+/** ターン開始時の手札数 */
+export const handSizeOnLessonStart = 3;
+
+/** 手札の最大枚数 */
+export const maxHandSize = 5;
+
+// TODO: 初期カードセットをどこかに定義する
+//       - 集中型: 試行錯誤、アピールの基本x2, ポーズの基本, 表情の基本x2, 表現の基本x2
+export const createIdolInProduction = (params: {
+  cards: CardInProduction[];
+  idGenerator: IdGenerator;
+  idolDefinitionId: string;
+  specificCardEnhanced: boolean;
+  specificProducerItemEnhanced: boolean;
+}): IdolInProduction => {
+  const idolDefinition = getIdolDataById(params.idolDefinitionId);
+  const characterDefinition = getCharacterDataById(idolDefinition.characterId);
+  const specificCardDefinition = getCardDataById(idolDefinition.specificCardId);
+  const specificProducerItemDefinition = getProducerItemDataById(
+    idolDefinition.specificProducerItemId,
+  );
+  return {
+    // アイドル固有 ＞ メモリーカード供給 ＞ 初期カード、の順でデッキを構築する
+    deck: [
+      {
+        id: params.idGenerator(),
+        definition: specificCardDefinition,
+        enhanced: params.specificCardEnhanced,
+        enabled: true,
+      },
+      ...params.cards,
+    ],
+    definition: idolDefinition,
+    life: characterDefinition.maxLife,
+    maxLife: characterDefinition.maxLife,
+    producerItems: [
+      {
+        id: params.idGenerator(),
+        definition: specificProducerItemDefinition,
+        enhanced: params.specificProducerItemEnhanced,
+      },
+    ],
+  };
+};
+
+const createIdol = (params: { idolInProduction: IdolInProduction }): Idol => {
+  return {
+    life: params.idolInProduction.life,
+    modifiers: [],
+    original: params.idolInProduction,
+    totalCardUsageCount: 0,
+    vitality: 0,
+  };
+};
+
+export const prepareCardsForLesson = (
+  cardsInProduction: CardInProduction[],
+): Card[] => {
+  return cardsInProduction.map((cardInProduction) => {
+    return {
+      id: cardInProduction.id,
+      original: cardInProduction,
+      enhancements: cardInProduction.enhanced ? [{ kind: "original" }] : [],
+    };
+  });
+};
+
+export const createLesson = (params: {
+  clearScoreThresholds: Lesson["clearScoreThresholds"];
+  getRandom: GetRandom;
+  idolInProduction: IdolInProduction;
+  lastTurnNumber: Lesson["lastTurnNumber"];
+}): Lesson => {
+  const cards = prepareCardsForLesson(params.idolInProduction.deck);
+  return {
+    cards,
+    clearScoreThresholds: params.clearScoreThresholds,
+    deck: shuffleArray(
+      cards.map((card) => card.id),
+      params.getRandom,
+    ),
+    discardPile: [],
+    hand: [],
+    idol: createIdol({
+      idolInProduction: params.idolInProduction,
+    }),
+    lastTurnNumber: params.lastTurnNumber,
+    removedCardPile: [],
+    selectedCardInHandIndex: undefined,
+    score: 0,
+    turnNumber: 1,
+    remainingTurns: 0,
+  };
+};
+
+/**
+ * レッスンのクリアに対するスコア進捗を計算する
+ */
+export const calculateClearScoreProgress = (
+  score: Lesson["score"],
+  clearScoreThresholds: NonNullable<Lesson["clearScoreThresholds"]>,
+): {
+  clearScoreProgressPercentage: number;
+  necessaryClearScore: number;
+  necessaryPerfectScore: number | undefined;
+  remainingClearScore: number;
+  remainingPerfectScore: number | undefined;
+} => {
+  return {
+    necessaryClearScore: clearScoreThresholds.clear,
+    necessaryPerfectScore: clearScoreThresholds.perfect,
+    remainingClearScore: Math.max(0, clearScoreThresholds.clear - score),
+    remainingPerfectScore:
+      clearScoreThresholds.perfect !== undefined
+        ? Math.max(0, clearScoreThresholds.perfect - score)
+        : undefined,
+    clearScoreProgressPercentage: Math.floor(
+      (score * 100) / clearScoreThresholds.clear,
+    ),
+  };
+};
+
+export const createLessonGamePlay = (params: {
+  clearScoreThresholds?: Lesson["clearScoreThresholds"];
+  idolInProduction: IdolInProduction;
+  getRandom?: GetRandom;
+  idGenerator?: IdGenerator;
+  lastTurnNumber: Lesson["lastTurnNumber"];
+}): LessonGamePlay => {
+  const clearScoreThresholds =
+    params.clearScoreThresholds !== undefined
+      ? params.clearScoreThresholds
+      : undefined;
+  const getRandom = params.getRandom ? params.getRandom : Math.random;
+  const idGenerator = params.idGenerator
+    ? params.idGenerator
+    : createIdGenerator();
+  return {
+    getRandom,
+    idGenerator,
+    initialLesson: createLesson({
+      clearScoreThresholds,
+      getRandom,
+      idolInProduction: params.idolInProduction,
+      lastTurnNumber: params.lastTurnNumber,
+    }),
+    updates: [],
+  };
+};
+
+export const calculateActualLastTurnNumber = (lesson: Lesson): number =>
+  lesson.lastTurnNumber + lesson.remainingTurns;
+
+/** 残りターン数を計算する、最終ターンは1 */
+export const calculateActualRemainingTurns = (lesson: Lesson): number =>
+  calculateActualLastTurnNumber(lesson) - lesson.turnNumber + 1;
+
+/** 「消費体力減少」・「消費体力削減」・「消費体力増加」を反映したコストを返す */
+export const calculateActualActionCost = (
+  cost: ActionCost,
+  modifiers: Modifier[],
+): ActionCost => {
+  switch (cost.kind) {
+    case "focus":
+    case "motivation":
+    case "goodCondition":
+    case "positiveImpression": {
+      return cost;
+    }
+    case "life":
+    case "normal": {
+      const lifeConsumptionReduction = modifiers.find(
+        (e) => e.kind === "lifeConsumptionReduction",
+      );
+      const lifeConsumptionReductionValue =
+        lifeConsumptionReduction !== undefined &&
+        "value" in lifeConsumptionReduction
+          ? lifeConsumptionReduction.value
+          : 0;
+      const halfLifeConsumption =
+        modifiers.find((e) => e.kind === "halfLifeConsumption") !== undefined;
+      const hasDoubleLifeConsumption =
+        modifiers.find((e) => e.kind === "doubleLifeConsumption") !== undefined;
+      const value = Math.max(cost.value - lifeConsumptionReductionValue, 0);
+      let rate = hasDoubleLifeConsumption ? 2 : 1;
+      rate = rate / (halfLifeConsumption ? 2 : 1);
+      return {
+        kind: cost.kind,
+        value: Math.ceil(value * rate),
+      };
+    }
+    default: {
+      const unreachable: never = cost.kind;
+      throw new Error(`Unreachable statement`);
+    }
+  }
+};
+
+/**
+ * レッスン更新クエリを適用した結果のレッスンを返す
+ *
+ * - Redux の Action のような、単純な setter の塊
+ *   - ロジックはなるべく含まない
+ *     - 例えば、バリデーションや閾値処理などは、更新クエリを生成する際に行う
+ */
+export const patchUpdates = (
+  lesson: Lesson,
+  updates: LessonUpdateQuery[],
+): Lesson => {
+  let newLesson = lesson;
+  for (const update of updates) {
+    switch (update.kind) {
+      case "cardEnhancement": {
+        newLesson = {
+          ...newLesson,
+          cards: newLesson.cards.map((card) =>
+            update.cardIds.includes(card.id)
+              ? {
+                  ...card,
+                  enhancements: [...card.enhancements, { kind: "effect" }],
+                }
+              : card,
+          ),
+        };
+        break;
+      }
+      case "cardPlacement": {
+        newLesson = {
+          ...newLesson,
+          ...(update.deck ? { deck: update.deck } : {}),
+          ...(update.discardPile ? { discardPile: update.discardPile } : {}),
+          ...(update.hand ? { hand: update.hand } : {}),
+          ...(update.removedCardPile
+            ? { removedCardPile: update.removedCardPile }
+            : {}),
+        };
+        break;
+      }
+      case "cards": {
+        newLesson = {
+          ...newLesson,
+          cards: update.cards,
+        };
+        break;
+      }
+      case "life": {
+        newLesson = {
+          ...newLesson,
+          idol: {
+            ...newLesson.idol,
+            life: newLesson.idol.life + update.actual,
+          },
+        };
+        break;
+      }
+      case "modifier": {
+        let newModifiers: Modifier[] = newLesson.idol.modifiers;
+        const sameKindIndex = newLesson.idol.modifiers.findIndex(
+          (e) => e.kind === update.modifier.kind,
+        );
+        // 同種の状態修正がない場合は新規追加、または特殊な状態修正の場合は新規追加
+        if (
+          sameKindIndex === -1 ||
+          update.modifier.kind === "delayedEffect" ||
+          update.modifier.kind === "effectActivationAtEndOfTurn" ||
+          update.modifier.kind === "effectActivationUponCardUsage"
+        ) {
+          newModifiers = [...newModifiers, update.modifier];
+        } else if (update.modifier.kind === "doubleEffect") {
+          if (update.modifier.times === 1) {
+            newModifiers = [...newModifiers, update.modifier];
+          } else {
+            const foundIndex = newModifiers.findIndex(
+              (e) => e.kind === "doubleEffect",
+            );
+            const tmp = newModifiers.slice();
+            tmp.splice(foundIndex, 1);
+            newModifiers = tmp;
+          }
+        } else {
+          const updateModifierKind = update.modifier.kind;
+          newModifiers = newModifiers.map((modifier) => {
+            let newModifier: Modifier = modifier;
+            switch (updateModifierKind) {
+              // duration の設定もあるが、現在は常に 1 なので無視する
+              case "additionalCardUsageCount": {
+                if (modifier.kind === update.modifier.kind) {
+                  newModifier = {
+                    ...modifier,
+                    amount: modifier.amount + update.modifier.amount,
+                  };
+                }
+                break;
+              }
+              case "debuffProtection": {
+                if (modifier.kind === update.modifier.kind) {
+                  newModifier = {
+                    ...modifier,
+                    times: modifier.times + update.modifier.times,
+                  };
+                }
+                break;
+              }
+              case "doubleLifeConsumption":
+              case "excellentCondition":
+              case "halfLifeConsumption":
+              case "goodCondition":
+              case "mightyPerformance":
+              case "noVitalityIncrease": {
+                if (modifier.kind === update.modifier.kind) {
+                  newModifier = {
+                    ...modifier,
+                    duration: modifier.duration + update.modifier.duration,
+                  };
+                }
+                break;
+              }
+              case "focus":
+              case "motivation":
+              case "positiveImpression": {
+                if (modifier.kind === update.modifier.kind) {
+                  newModifier = {
+                    ...modifier,
+                    amount: modifier.amount + update.modifier.amount,
+                  };
+                }
+                break;
+              }
+              case "lifeConsumptionReduction": {
+                if (modifier.kind === update.modifier.kind) {
+                  newModifier = {
+                    ...modifier,
+                    value: modifier.value + update.modifier.value,
+                  };
+                }
+                break;
+              }
+              default:
+                const unreachable: never = updateModifierKind;
+                throw new Error(`Unreachable statement`);
+            }
+            return newModifier;
+          });
+          newModifiers = newModifiers.filter(
+            (modifier) =>
+              ("amount" in modifier && modifier.amount > 0) ||
+              ("duration" in modifier && modifier.duration > 0) ||
+              ("times" in modifier && modifier.times > 0) ||
+              ("value" in modifier && modifier.value > 0),
+          );
+        }
+        newLesson = {
+          ...newLesson,
+          idol: {
+            ...newLesson.idol,
+            modifiers: newModifiers,
+          },
+        };
+        break;
+      }
+      case "remainingTurns": {
+        newLesson = {
+          ...newLesson,
+          remainingTurns: newLesson.remainingTurns + update.amount,
+        };
+        break;
+      }
+      case "score": {
+        newLesson = {
+          ...newLesson,
+          score: newLesson.score + update.actual,
+        };
+        break;
+      }
+      case "selectedCardInHandIndex": {
+        newLesson = {
+          ...newLesson,
+          selectedCardInHandIndex: update.index,
+        };
+        break;
+      }
+      case "turnNumberIncrease": {
+        newLesson = {
+          ...newLesson,
+          turnNumber: newLesson.turnNumber + 1,
+        };
+        break;
+      }
+      case "vitality": {
+        newLesson = {
+          ...newLesson,
+          idol: {
+            ...newLesson.idol,
+            vitality: newLesson.idol.vitality + update.actual,
+          },
+        };
+        break;
+      }
+      default: {
+        const unreachable: never = update;
+        throw new Error(`Unreachable statement`);
+      }
+    }
+  }
+  return newLesson;
+};

--- a/src/text-generation.test.ts
+++ b/src/text-generation.test.ts
@@ -59,9 +59,9 @@ describe("generateEffectText", () => {
       name: "generateCard",
     },
     {
-      args: [{ kind: "increaseTurns", amount: 1 }],
+      args: [{ kind: "increaseRemainingTurns", amount: 1 }],
       expected: "{{ターン追加}}+1",
-      name: "increaseTurns",
+      name: "increaseRemainingTurns",
     },
     {
       args: [

--- a/src/text-generation.ts
+++ b/src/text-generation.ts
@@ -57,7 +57,7 @@ const globalKeywords = {
   generateCard: "生成",
   goodCondition: "好調",
   halfLifeConsumption: "消費体力減少",
-  increaseTurns: "ターン追加",
+  increaseRemainingTurns: "ターン追加",
   lifeConsumptionReduction: "消費体力削減",
   mentalSkillCard: "メンタルスキルカード",
   mightyPerformance: "パラメータ上昇量増加",
@@ -133,7 +133,7 @@ const generateModifierText = (modifier: Modifier): string => {
           : `${modifier.delay}ターン後、`) + generateEffectText(modifier.effect)
       );
     case "doubleEffect":
-      return `次に使用するスキルカードの効果をもう1回発動（${modifier.times}回）`;
+      return `次に使用するスキルカードの効果をもう1回発動（1回）`;
     case "doubleLifeConsumption":
       return `${kwd("doubleLifeConsumption")}${modifier.duration}ターン`;
     case "effectActivationAtEndOfTurn":
@@ -247,8 +247,8 @@ const generateEffectWithoutConditionText = (effect: Effect): string => {
       return "手札をすべて入れ替える";
     case "generateCard":
       return `ランダムな強化済みスキルカード（SSR）を、手札に${kwd("generateCard")}`;
-    case "increaseTurns":
-      return `${kwd("increaseTurns")}+${effect.amount}`;
+    case "increaseRemainingTurns":
+      return `${kwd("increaseRemainingTurns")}+${effect.amount}`;
     case "getModifier":
       return generateModifierText(effect.modifier);
     case "multiplyModifier":

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,47 @@
+import { validateNumberInRange } from "./utils";
+
+describe("validateNumberInRange", () => {
+  const testCases: Array<{
+    args: Parameters<typeof validateNumberInRange>;
+    expected: ReturnType<typeof validateNumberInRange>;
+  }> = [
+    {
+      args: [1, { min: 1 }],
+      expected: true,
+    },
+    {
+      args: [0, { min: 1 }],
+      expected: false,
+    },
+    {
+      args: [1, { max: 1 }],
+      expected: true,
+    },
+    {
+      args: [2, { max: 1 }],
+      expected: false,
+    },
+    {
+      args: [1, { min: 1, max: 3 }],
+      expected: true,
+    },
+    {
+      args: [3, { min: 1, max: 3 }],
+      expected: true,
+    },
+    {
+      args: [0, { min: 1, max: 3 }],
+      expected: false,
+    },
+    {
+      args: [4, { min: 1, max: 3 }],
+      expected: false,
+    },
+  ];
+  test.each(testCases)(
+    "$args.0, $args.1 => $expected",
+    ({ args, expected }) => {
+      expect(validateNumberInRange(...args)).toBe(expected);
+    },
+  );
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,49 @@
+import { GetRandom, IdGenerator, RangedNumber } from "./types";
+
+/**
+ * Shuffle an array with the Fisher–Yates algorithm.
+ *
+ * Ref) https://www.30secondsofcode.org/js/s/shuffle/
+ */
+export const shuffleArray = <Element>(
+  array: Element[],
+  getRandom: GetRandom,
+): Element[] => {
+  const copied = array.slice();
+  let m = copied.length;
+  while (m) {
+    const i = Math.floor(getRandom() * m);
+    m--;
+    [copied[m], copied[i]] = [copied[i], copied[m]];
+  }
+  return copied;
+};
+
+/**
+ * 一意のIDを生成する
+ *
+ * - 1レッスンまたは1プロデュース毎に1インスタンスを生成して共有する
+ * - TODO: データロードの際の始点の復元
+ */
+export const createIdGenerator = (): IdGenerator => {
+  // 整数のオーバーフローは考えない、 Number.MAX_SAFE_INTEGER を超えることはなさそう
+  let counter = 0;
+  return () => {
+    counter++;
+    return `${counter}`;
+  };
+};
+
+export const validateNumberInRange = (
+  target: number,
+  range: RangedNumber,
+): boolean => {
+  if ("min" in range && "max" in range) {
+    return range.min <= target && target <= range.max;
+  } else if ("min" in range) {
+    return range.min <= target;
+  } else if ("max" in range) {
+    return target <= range.max;
+  }
+  throw new Error("Invalid range");
+};


### PR DESCRIPTION
## 🤔 Lesson の状態差分を LessonUpdateQuery で示す設計
### なぜ必要か？

- 外部仕様上の要件
  - スキルカード選択時のプレビューを実装できること
  - 履歴ボタンから見れる履歴を実装できること
- その他の要件
  - 初期レッスン状態から順番通りにpatchしていつの時点の状態でも復元できること、いわゆるReduxのタイムトラベル機能
  - データ永続化のためにシリアライズ可能であること
  - UI上のアニメーションやインタラクションへのクエリを作るために、ユーザーの操作起点の状態変化よりも、ある程度細かい単位で表現する必要があること
    - 例えば、「パラメータ+7（2回）」のスキルカード使用時に結果の「14」だけが状態に残る形だと、「UI上で7が上がって、また7が上がる」というインタラクションが表現できない
    - この LessonUpdateQuery の単位がインタラクション・アニメーションの表現に対して十分かについては、論理的な保証はないのだが、まぁ概ねで良い
      - UIの都合が大きいので考えてもわからないし、ある程度は外部仕様を諦めることもできる
- 補足
  - いまのところ unpatch はなくても良さそう

### 大枠の設計候補

- 🙅  A) 状態の更新処理と、各種ログを別に生成する
  - 「初期レッスン状態から順番通りにpatchしていつの時点の状態でも復元できること」を満たすのが難しい
- 🙆‍♀️  B) 状態に対する更新クエリを生成する、つまりGitのコミットみたいな仕組みにする
  - 更新クエリが各種ログの要件を満たせるかが不明瞭になる
    - 必須の「スキルカード選択時のプレビュー」「履歴ボタンから見れる履歴」は開発時に考慮して、他はほどほどに動けばいいのであまり考えないで作る
      - アニメーションはできる範囲でいいし、タイムトラベル機能もターン毎くらいで状態復元できればいい
  - 都度都度 `patch(state, update)` みたいなことをして現在の状態を作る必要があるので重い
    - つうて、オンメモリ処理だし、1レッスンの更新クエリ量は1000未満だろうし、誤差レベル
  - おそらくAより実装量が多くてめんどい
    - 仕方なし

### 汎用的なJSのオブジェクトに対する差分で表現する？

- とりあえず、JSのオブジェクトに対する汎用的な差分ロジックってあるの？
  - 鉄板のものはなさそう
    - https://zenn.dev/cbmrham/articles/202404-ts_recursive_diff_lib
      - https://github.com/cbmrham/recursive-diff
    - https://www.npmjs.com/package/json-diff
- そもそもで、「JSのオブジェクトに対する汎用的な差分表現」でゲームの状態更新クエリを表現するのは、可能かもしれないけど不可能な可能性が高かった
  - 全体的にボツ

### ゲームに沿った形での表現

- こっちの方が制約がなくて良さそう