### PR TITLE
Modifier定義や更新クエリ上の振る舞いを変更

### DIFF
--- a/src/lesson-mutation.test.ts
+++ b/src/lesson-mutation.test.ts
@@ -6,11 +6,13 @@ import {
   IdolDefinition,
   IdolInProduction,
   Lesson,
+  Modifier,
 } from "./types";
 import { cards, getCardDataById } from "./data/card";
 import {
   activateEffectsOnTurnStart,
   addCardsToHandOrDiscardPile,
+  calculateCostConsumption,
   calculatePerformingScoreEffect,
   calculatePerformingVitalityEffect,
   canApplyEffect,
@@ -19,7 +21,7 @@ import {
   drawCardsFromDeck,
   drawCardsOnTurnStart,
   useCard,
-  validateCostComsumution,
+  validateCostConsumution,
 } from "./lesson-mutation";
 import {
   createIdolInProduction,
@@ -272,10 +274,10 @@ describe("createCardPlacementDiff", () => {
     expect(createCardPlacementDiff(...args)).toStrictEqual(expected);
   });
 });
-describe("validateCostComsumution", () => {
+describe("validateCostConsumution", () => {
   const testCases: Array<{
-    args: Parameters<typeof validateCostComsumution>;
-    expected: ReturnType<typeof validateCostComsumution>;
+    args: Parameters<typeof validateCostConsumution>;
+    expected: ReturnType<typeof validateCostConsumution>;
     name: string;
   }> = [
     {
@@ -456,10 +458,10 @@ describe("validateCostComsumution", () => {
     },
   ];
   test.each(testCases)("$name", ({ args, expected }) => {
-    expect(validateCostComsumution(...args)).toStrictEqual(expected);
+    expect(validateCostConsumution(...args)).toStrictEqual(expected);
   });
 });
-// validateCostComsumution で検証できる内容はそちらで行う
+// validateCostConsumution で検証できる内容はそちらで行う
 describe("canUseCard", () => {
   const testCases: Array<{
     args: Parameters<typeof canUseCard>;
@@ -999,6 +1001,229 @@ describe("canApplyEffect", () => {
     expect(canApplyEffect(...args)).toBe(expected);
   });
 });
+describe("calculateCostConsumption", () => {
+  const testCases: Array<{
+    args: Parameters<typeof calculateCostConsumption>;
+    expected: ReturnType<typeof calculateCostConsumption>;
+    name: string;
+  }> = [
+    {
+      name: "normalコストでvitality以下の値の時、全コストをvitalityで払う",
+      args: [
+        {
+          vitality: 3,
+        } as Idol,
+        { kind: "normal", value: 3 },
+        createIdGenerator(),
+      ],
+      expected: [{ kind: "vitality", actual: -3, max: -3 }],
+    },
+    {
+      name: "normalコストでvitalityを超える値の時、一部コストをvitalityで払い、一部をlifeで払う",
+      args: [
+        {
+          life: 1,
+          vitality: 3,
+        } as Idol,
+        { kind: "normal", value: 4 },
+        createIdGenerator(),
+      ],
+      expected: [
+        { kind: "vitality", actual: -3, max: -4 },
+        { kind: "life", actual: -1, max: -1 },
+      ],
+    },
+    {
+      name: "normalコストでvitalityとlifeの合計を超える値の時、一部コストをvitalityとlifeで払う",
+      args: [
+        {
+          life: 1,
+          vitality: 3,
+        } as Idol,
+        { kind: "normal", value: 5 },
+        createIdGenerator(),
+      ],
+      expected: [
+        { kind: "vitality", actual: -3, max: -5 },
+        { kind: "life", actual: -1, max: -2 },
+      ],
+    },
+    {
+      name: "normalコストでvitalityもlifeも0の時、lifeで0コストを払う",
+      args: [
+        {
+          life: 0,
+          vitality: 0,
+        } as Idol,
+        { kind: "normal", value: 3 },
+        createIdGenerator(),
+      ],
+      expected: [{ kind: "life", actual: 0, max: -3 }],
+    },
+    {
+      name: "lifeコストでlife以下の値の時、全コストをlifeで払う",
+      args: [
+        {
+          life: 3,
+        } as Idol,
+        { kind: "life", value: 3 },
+        createIdGenerator(),
+      ],
+      expected: [{ kind: "life", actual: -3, max: -3 }],
+    },
+    {
+      name: "lifeコストでlifeを超える値の時、一部コストをlifeで払う",
+      args: [
+        {
+          life: 2,
+        } as Idol,
+        { kind: "life", value: 3 },
+        createIdGenerator(),
+      ],
+      expected: [{ kind: "life", actual: -2, max: -3 }],
+    },
+    {
+      name: "lifeコストでlifeが0の時、0コストをlifeで払う",
+      args: [
+        {
+          life: 0,
+        } as Idol,
+        { kind: "life", value: 3 },
+        createIdGenerator(),
+      ],
+      expected: [{ kind: "life", actual: 0, max: -3 }],
+    },
+    {
+      name: "amountプロパティのmodifierコストで、値がアイドルが持つmodifier以下の時、全部のコストを払う",
+      args: [
+        {
+          modifiers: [{ kind: "focus", amount: 3, id: "a" }],
+        } as Idol,
+        { kind: "focus", value: 3 },
+        createIdGenerator(),
+      ],
+      expected: [
+        {
+          kind: "modifier",
+          actual: {
+            kind: "focus",
+            amount: -3,
+            id: expect.any(String),
+            updateTargetId: "a",
+          },
+          max: {
+            kind: "focus",
+            amount: -3,
+            id: expect.any(String),
+            updateTargetId: "a",
+          },
+        },
+      ],
+    },
+    {
+      name: "amountプロパティのmodifierコストで、値がアイドルが持つmodifierを超える時、一部のコストを払う",
+      args: [
+        {
+          modifiers: [{ kind: "focus", amount: 3, id: "a" }],
+        } as Idol,
+        { kind: "focus", value: 4 },
+        createIdGenerator(),
+      ],
+      expected: [
+        {
+          kind: "modifier",
+          actual: {
+            kind: "focus",
+            amount: -3,
+            id: expect.any(String),
+            updateTargetId: "a",
+          },
+          max: {
+            kind: "focus",
+            amount: -4,
+            id: expect.any(String),
+            updateTargetId: "a",
+          },
+        },
+      ],
+    },
+    {
+      name: "amountプロパティのmodifierコストで、アイドルが相当するmodifierを持たない時、結果を返さない",
+      args: [
+        { modifiers: [] as Modifier[] } as Idol,
+        { kind: "focus", value: 3 },
+        createIdGenerator(),
+      ],
+      expected: [],
+    },
+    {
+      name: "durationプロパティのmodifierコストで、値がアイドルが持つmodifier以下の時、全部のコストを払う",
+      args: [
+        {
+          modifiers: [{ kind: "goodCondition", duration: 3, id: "a" }],
+        } as Idol,
+        { kind: "goodCondition", value: 3 },
+        createIdGenerator(),
+      ],
+      expected: [
+        {
+          kind: "modifier",
+          actual: {
+            kind: "goodCondition",
+            duration: -3,
+            id: expect.any(String),
+            updateTargetId: "a",
+          },
+          max: {
+            kind: "goodCondition",
+            duration: -3,
+            id: expect.any(String),
+            updateTargetId: "a",
+          },
+        },
+      ],
+    },
+    {
+      name: "durationプロパティのmodifierコストで、値がアイドルが持つmodifierを超える時、一部のコストを払う",
+      args: [
+        {
+          modifiers: [{ kind: "goodCondition", duration: 3, id: "a" }],
+        } as Idol,
+        { kind: "goodCondition", value: 4 },
+        createIdGenerator(),
+      ],
+      expected: [
+        {
+          kind: "modifier",
+          actual: {
+            kind: "goodCondition",
+            duration: -3,
+            id: expect.any(String),
+            updateTargetId: "a",
+          },
+          max: {
+            kind: "goodCondition",
+            duration: -4,
+            id: expect.any(String),
+            updateTargetId: "a",
+          },
+        },
+      ],
+    },
+    {
+      name: "amountプロパティのmodifierコストで、アイドルが相当するmodifierを持たない時、結果を返さない",
+      args: [
+        { modifiers: [] as Modifier[] } as Idol,
+        { kind: "goodCondition", value: 3 },
+        createIdGenerator(),
+      ],
+      expected: [],
+    },
+  ];
+  test.each(testCases)("$name", ({ args, expected }) => {
+    expect(calculateCostConsumption(...args)).toStrictEqual(expected);
+  });
+});
 describe("calculatePerformingScoreEffect", () => {
   const testCases: {
     args: Parameters<typeof calculatePerformingScoreEffect>;
@@ -1479,21 +1704,37 @@ describe("activateEffectsOnTurnStart", () => {
     expect(updates.filter((e) => e.kind === "modifier")).toStrictEqual([
       {
         kind: "modifier",
-        modifier: {
+        actual: {
           kind: "delayedEffect",
           delay: -1,
-          id: "x",
           effect: expect.any(Object),
+          id: expect.any(String),
+          updateTargetId: "x",
+        },
+        max: {
+          kind: "delayedEffect",
+          delay: -1,
+          effect: expect.any(Object),
+          id: expect.any(String),
+          updateTargetId: "x",
         },
         reason: expect.any(Object),
       },
       {
         kind: "modifier",
-        modifier: {
+        actual: {
           kind: "delayedEffect",
           delay: -1,
-          id: "y",
           effect: expect.any(Object),
+          id: expect.any(String),
+          updateTargetId: "y",
+        },
+        max: {
+          kind: "delayedEffect",
+          delay: -1,
+          effect: expect.any(Object),
+          id: expect.any(String),
+          updateTargetId: "y",
         },
         reason: expect.any(Object),
       },
@@ -1537,11 +1778,19 @@ describe("activateEffectsOnTurnStart", () => {
     expect(updates.filter((e) => e.kind === "modifier")).toStrictEqual([
       {
         kind: "modifier",
-        modifier: {
+        actual: {
           kind: "delayedEffect",
           delay: -1,
-          id: "x",
+          id: expect.any(String),
           effect: expect.any(Object),
+          updateTargetId: "x",
+        },
+        max: {
+          kind: "delayedEffect",
+          delay: -1,
+          id: expect.any(String),
+          effect: expect.any(Object),
+          updateTargetId: "x",
         },
         reason: expect.any(Object),
       },
@@ -1609,31 +1858,55 @@ describe("activateEffectsOnTurnStart", () => {
     expect(updates.filter((e) => e.kind === "modifier")).toStrictEqual([
       {
         kind: "modifier",
-        modifier: {
+        actual: {
           kind: "delayedEffect",
           delay: -1,
-          id: "x",
           effect: expect.any(Object),
+          id: expect.any(String),
+          updateTargetId: "x",
+        },
+        max: {
+          kind: "delayedEffect",
+          delay: -1,
+          effect: expect.any(Object),
+          id: expect.any(String),
+          updateTargetId: "x",
         },
         reason: expect.any(Object),
       },
       {
         kind: "modifier",
-        modifier: {
+        actual: {
           kind: "delayedEffect",
           delay: -1,
-          id: "y",
           effect: expect.any(Object),
+          id: expect.any(String),
+          updateTargetId: "y",
+        },
+        max: {
+          kind: "delayedEffect",
+          delay: -1,
+          effect: expect.any(Object),
+          id: expect.any(String),
+          updateTargetId: "y",
         },
         reason: expect.any(Object),
       },
       {
         kind: "modifier",
-        modifier: {
+        actual: {
           kind: "delayedEffect",
           delay: -1,
-          id: "z",
           effect: expect.any(Object),
+          id: expect.any(String),
+          updateTargetId: "z",
+        },
+        max: {
+          kind: "delayedEffect",
+          delay: -1,
+          effect: expect.any(Object),
+          id: expect.any(String),
+          updateTargetId: "z",
         },
         reason: expect.any(Object),
       },
@@ -1675,11 +1948,19 @@ describe("activateEffectsOnTurnStart", () => {
     expect(updates.filter((e) => e.kind === "modifier")).toStrictEqual([
       {
         kind: "modifier",
-        modifier: {
+        actual: {
           kind: "delayedEffect",
           delay: -1,
-          id: "x",
           effect: expect.any(Object),
+          id: expect.any(String),
+          updateTargetId: "x",
+        },
+        max: {
+          kind: "delayedEffect",
+          delay: -1,
+          effect: expect.any(Object),
+          id: expect.any(String),
+          updateTargetId: "x",
         },
         reason: expect.any(Object),
       },
@@ -1730,7 +2011,7 @@ describe("activateEffectsOnTurnStart", () => {
     ]);
   });
 });
-describe("useCard, previe:false", () => {
+describe("useCard preview:false", () => {
   describe("使用した手札を捨札か除外へ移動", () => {
     test("「レッスン中1回」ではない手札を使った時は、捨札へ移動", () => {
       const lesson = createLessonForTest({
@@ -1781,35 +2062,9 @@ describe("useCard, previe:false", () => {
       expect(update.removedCardPile).toStrictEqual(["a"]);
     });
   });
+  // 基本的には calculateCostConsumption のテストで行う
   describe("コスト消費", () => {
-    test("全て元気で賄った時のnormal", () => {
-      const lesson = createLessonForTest({
-        cards: [
-          {
-            id: "a",
-            definition: getCardDataById("apirunokihon"),
-            enabled: true,
-            enhanced: false,
-          },
-        ],
-      });
-      lesson.hand = ["a"];
-      lesson.idol.vitality = 4;
-      const { updates } = useCard(lesson, 1, {
-        selectedCardInHandIndex: 0,
-        getRandom: () => 0,
-        idGenerator: createIdGenerator(),
-        preview: false,
-      });
-      expect(updates.find((e) => e.kind === "vitality")).toStrictEqual({
-        kind: "vitality",
-        actual: -4,
-        max: -4,
-        reason: expect.any(Object),
-      });
-      expect(updates.find((e) => e.kind === "life")).toBeUndefined();
-    });
-    test("一部を元気で賄った時のnormal", () => {
+    test("it works", () => {
       const lesson = createLessonForTest({
         cards: [
           {
@@ -1828,101 +2083,22 @@ describe("useCard, previe:false", () => {
         idGenerator: createIdGenerator(),
         preview: false,
       });
-      expect(updates.find((e) => e.kind === "vitality")).toStrictEqual({
-        kind: "vitality",
-        actual: -3,
-        max: -4,
-        reason: expect.any(Object),
-      });
-      expect(updates.find((e) => e.kind === "life")).toStrictEqual({
-        kind: "life",
-        actual: -1,
-        max: -1,
-        reason: expect.any(Object),
-      });
-    });
-    test("life", () => {
-      const lesson = createLessonForTest({
-        cards: [
-          {
-            id: "a",
-            definition: getCardDataById("genkinaaisatsu"),
-            enabled: true,
-            enhanced: false,
-          },
-        ],
-      });
-      lesson.hand = ["a"];
-      const { updates } = useCard(lesson, 1, {
-        selectedCardInHandIndex: 0,
-        getRandom: () => 0,
-        idGenerator: createIdGenerator(),
-        preview: false,
-      });
-      expect(updates.find((e) => e.kind === "life")).toStrictEqual({
-        kind: "life",
-        actual: -4,
-        max: -4,
-        reason: expect.any(Object),
-      });
-    });
-    test("プロパティにamountがあるmodifier", () => {
-      const lesson = createLessonForTest({
-        cards: [
-          {
-            id: "a",
-            definition: getCardDataById("minnadaisuki"),
-            enabled: true,
-            enhanced: false,
-          },
-        ],
-      });
-      lesson.hand = ["a"];
-      lesson.idol.modifiers = [{ kind: "motivation", amount: 3, id: "x" }];
-      const { updates } = useCard(lesson, 1, {
-        selectedCardInHandIndex: 0,
-        getRandom: () => 0,
-        idGenerator: createIdGenerator(),
-        preview: false,
-      });
-      expect(updates.find((e) => e.kind === "modifier")).toStrictEqual({
-        kind: "modifier",
-        modifier: {
-          kind: "motivation",
-          amount: 3,
-          id: expect.any(String),
+      expect(updates.filter((e) => e.kind === "vitality")).toStrictEqual([
+        {
+          kind: "vitality",
+          actual: -3,
+          max: -4,
+          reason: expect.any(Object),
         },
-        reason: expect.any(Object),
-      });
-    });
-    test("プロパティにdurationがあるmodifier", () => {
-      const lesson = createLessonForTest({
-        cards: [
-          {
-            id: "a",
-            definition: getCardDataById("sonzaikan"),
-            enabled: true,
-            enhanced: false,
-          },
-        ],
-      });
-      lesson.hand = ["a"];
-      lesson.idol.modifiers = [{ kind: "goodCondition", duration: 2, id: "x" }];
-      const { updates } = useCard(lesson, 1, {
-        selectedCardInHandIndex: 0,
-        getRandom: () => 0,
-        idGenerator: createIdGenerator(),
-        preview: false,
-      });
-      expect(updates.find((e) => e.kind === "modifier")).toStrictEqual({
-        kind: "modifier",
-        modifier: {
-          kind: "goodCondition",
-          duration: 2,
-          id: expect.any(String),
+      ]);
+      expect(updates.filter((e) => e.kind === "life")).toStrictEqual([
+        {
+          kind: "life",
+          actual: -1,
+          max: -1,
+          reason: expect.any(Object),
         },
-        reason: expect.any(Object),
-      });
+      ]);
     });
     test("状態修正により消費体力が変動", () => {
       const lesson = createLessonForTest({
@@ -1953,7 +2129,7 @@ describe("useCard, previe:false", () => {
       });
     });
   });
-  describe("効果発動・効果適用", () => {
+  describe("効果発動", () => {
     describe("効果適用条件を満たさない効果は適用されない", () => {
       test("「飛躍」は、集中が足りない時、パラメータ上昇は1回のみ適用する", () => {
         const lesson = createLessonForTest({
@@ -2000,7 +2176,7 @@ describe("useCard, previe:false", () => {
         expect(updates.filter((e) => e.kind === "score")).toHaveLength(2);
         expect(
           updates.filter(
-            (e) => e.kind === "modifier" && e.modifier.kind === "focus",
+            (e) => e.kind === "modifier" && e.actual.kind === "focus",
           ),
         ).toHaveLength(2);
         expect(updates.filter((e) => e.kind === "score")[0]).toStrictEqual({
@@ -2017,7 +2193,7 @@ describe("useCard, previe:false", () => {
         });
         expect(
           updates.filter(
-            (e) => e.kind === "modifier" && e.modifier.kind === "doubleEffect",
+            (e) => e.kind === "modifier" && e.actual.kind === "doubleEffect",
           ),
         ).toHaveLength(1);
       });
@@ -2252,7 +2428,7 @@ describe("useCard, previe:false", () => {
       });
     });
     describe("getModifier", () => {
-      test("it works", () => {
+      test("新規追加の時", () => {
         const lesson = createLessonForTest({
           cards: [
             {
@@ -2270,16 +2446,112 @@ describe("useCard, previe:false", () => {
           idGenerator: createIdGenerator(),
           preview: false,
         });
-        const update = updates.find((e) => e.kind === "modifier") as any;
-        expect(update).toStrictEqual({
-          kind: "modifier",
-          modifier: {
-            kind: "goodCondition",
-            duration: 2,
-            id: expect.any(String),
+        expect(updates.filter((e) => e.kind === "modifier")).toStrictEqual([
+          {
+            kind: "modifier",
+            actual: {
+              kind: "goodCondition",
+              duration: 2,
+              id: expect.any(String),
+            },
+            max: {
+              kind: "goodCondition",
+              duration: 2,
+              id: expect.any(String),
+            },
+            reason: expect.any(Object),
           },
-          reason: expect.any(Object),
+        ]);
+      });
+      test("既存の状態修正と合算の時", () => {
+        const lesson = createLessonForTest({
+          cards: [
+            {
+              id: "a",
+              definition: getCardDataById("furumainokihon"),
+              enabled: true,
+              enhanced: false,
+            },
+          ],
         });
+        lesson.hand = ["a"];
+        lesson.idol.modifiers = [
+          { kind: "goodCondition", duration: 1, id: "x" },
+        ];
+        const { updates } = useCard(lesson, 1, {
+          selectedCardInHandIndex: 0,
+          getRandom: () => 0,
+          idGenerator: createIdGenerator(),
+          preview: false,
+        });
+        expect(updates.filter((e) => e.kind === "modifier")).toStrictEqual([
+          {
+            kind: "modifier",
+            actual: {
+              kind: "goodCondition",
+              duration: 2,
+              id: expect.any(String),
+              updateTargetId: "x",
+            },
+            max: {
+              kind: "goodCondition",
+              duration: 2,
+              id: expect.any(String),
+              updateTargetId: "x",
+            },
+            reason: expect.any(Object),
+          },
+        ]);
+      });
+      test("既存の状態修正が存在しても新規追加になる状態修正の時", () => {
+        const lesson = createLessonForTest({
+          cards: [
+            {
+              id: "a",
+              definition: getCardDataById("enshutsukeikaku"),
+              enabled: true,
+              enhanced: false,
+            },
+          ],
+        });
+        lesson.hand = ["a"];
+        lesson.idol.modifiers = [
+          {
+            kind: "effectActivationUponCardUsage",
+            cardKind: "active",
+            id: "x",
+          } as Modifier,
+        ];
+        const { updates } = useCard(lesson, 1, {
+          selectedCardInHandIndex: 0,
+          getRandom: () => 0,
+          idGenerator: createIdGenerator(),
+          preview: false,
+        });
+        expect(
+          updates.filter(
+            (e) =>
+              e.kind === "modifier" &&
+              e.actual.kind === "effectActivationUponCardUsage",
+          ),
+        ).toStrictEqual([
+          {
+            kind: "modifier",
+            actual: {
+              kind: "effectActivationUponCardUsage",
+              cardKind: "active",
+              effect: expect.any(Object),
+              id: expect.any(String),
+            },
+            max: {
+              kind: "effectActivationUponCardUsage",
+              cardKind: "active",
+              effect: expect.any(Object),
+              id: expect.any(String),
+            },
+            reason: expect.any(Object),
+          },
+        ]);
       });
     });
     describe("increaseRemainingTurns", () => {
@@ -2348,16 +2620,24 @@ describe("useCard, previe:false", () => {
           idGenerator: createIdGenerator(),
           preview: false,
         });
-        const update = updates.find((e) => e.kind === "modifier") as any;
-        expect(update).toStrictEqual({
-          kind: "modifier",
-          modifier: {
-            kind: "positiveImpression",
-            amount: 5,
-            id: expect.any(String),
+        expect(updates.filter((e) => e.kind === "modifier")).toStrictEqual([
+          {
+            kind: "modifier",
+            actual: {
+              kind: "positiveImpression",
+              amount: 5,
+              id: expect.any(String),
+              updateTargetId: "y",
+            },
+            max: {
+              kind: "positiveImpression",
+              amount: 5,
+              id: expect.any(String),
+              updateTargetId: "y",
+            },
+            reason: expect.any(Object),
           },
-          reason: expect.any(Object),
-        });
+        ]);
       });
     });
     // calculatePerformingScoreEffect と calculatePerformingVitalityEffect のテストで検証できる内容はそちらで行う
@@ -2758,20 +3038,22 @@ describe("useCard, previe:false", () => {
         idGenerator: createIdGenerator(),
         preview: false,
       });
-      expect(updates1.filter((e) => e.kind === "modifier")).toStrictEqual([
-        // 「ファンシーチャーム」には、直接好印象を付与する効果もある
+      expect(
+        updates1.filter(
+          (e) =>
+            e.kind === "modifier" &&
+            e.actual.kind === "effectActivationUponCardUsage",
+        ),
+      ).toStrictEqual([
         {
           kind: "modifier",
-          modifier: {
-            kind: "positiveImpression",
-            amount: 3,
+          actual: {
+            kind: "effectActivationUponCardUsage",
+            cardKind: "mental",
+            effect: expect.any(Object),
             id: expect.any(String),
           },
-          reason: expect.any(Object),
-        },
-        {
-          kind: "modifier",
-          modifier: {
+          max: {
             kind: "effectActivationUponCardUsage",
             cardKind: "mental",
             effect: expect.any(Object),
@@ -2792,10 +3074,17 @@ describe("useCard, previe:false", () => {
       expect(updates2a.filter((e) => e.kind === "modifier")).toStrictEqual([
         {
           kind: "modifier",
-          modifier: {
+          actual: {
             kind: "positiveImpression",
             amount: 1,
             id: expect.any(String),
+            updateTargetId: expect.any(String),
+          },
+          max: {
+            kind: "positiveImpression",
+            amount: 1,
+            id: expect.any(String),
+            updateTargetId: expect.any(String),
           },
           reason: expect.any(Object),
         },
@@ -2807,7 +3096,7 @@ describe("useCard, previe:false", () => {
         idGenerator,
         preview: false,
       });
-      expect(updates2b.filter((e) => e.kind === "modifier")).toHaveLength(0);
+      expect(updates2b.filter((e) => e.kind === "modifier")).toStrictEqual([]);
     });
     test("「演出計画」は、アクティブスキルカード使用時、固定元気を付与する。メンタルスキルカード使用時は付与しない", () => {
       let lesson = createLessonForTest({
@@ -2840,20 +3129,22 @@ describe("useCard, previe:false", () => {
         idGenerator,
         preview: false,
       });
-      expect(updates1.filter((e) => e.kind === "modifier")).toStrictEqual([
-        // 「演出計画」には、直接絶好調を付与する効果もある
+      expect(
+        updates1.filter(
+          (e) =>
+            e.kind === "modifier" &&
+            e.actual.kind === "effectActivationUponCardUsage",
+        ),
+      ).toStrictEqual([
         {
           kind: "modifier",
-          modifier: {
-            kind: "excellentCondition",
-            duration: 3,
+          actual: {
+            kind: "effectActivationUponCardUsage",
+            cardKind: "active",
+            effect: expect.any(Object),
             id: expect.any(String),
           },
-          reason: expect.any(Object),
-        },
-        {
-          kind: "modifier",
-          modifier: {
+          max: {
             kind: "effectActivationUponCardUsage",
             cardKind: "active",
             effect: expect.any(Object),

--- a/src/lesson-mutation.test.ts
+++ b/src/lesson-mutation.test.ts
@@ -1878,7 +1878,7 @@ describe("useCard, previe:false", () => {
         ],
       });
       lesson.hand = ["a"];
-      lesson.idol.modifiers = [{ kind: "motivation", amount: 3 }];
+      lesson.idol.modifiers = [{ kind: "motivation", amount: 3, id: "x" }];
       const { updates } = useCard(lesson, 1, {
         selectedCardInHandIndex: 0,
         getRandom: () => 0,
@@ -1890,6 +1890,7 @@ describe("useCard, previe:false", () => {
         modifier: {
           kind: "motivation",
           amount: 3,
+          id: expect.any(String),
         },
         reason: expect.any(Object),
       });
@@ -1906,7 +1907,7 @@ describe("useCard, previe:false", () => {
         ],
       });
       lesson.hand = ["a"];
-      lesson.idol.modifiers = [{ kind: "goodCondition", duration: 2 }];
+      lesson.idol.modifiers = [{ kind: "goodCondition", duration: 2, id: "x" }];
       const { updates } = useCard(lesson, 1, {
         selectedCardInHandIndex: 0,
         getRandom: () => 0,
@@ -1918,6 +1919,7 @@ describe("useCard, previe:false", () => {
         modifier: {
           kind: "goodCondition",
           duration: 2,
+          id: expect.any(String),
         },
         reason: expect.any(Object),
       });
@@ -1934,7 +1936,9 @@ describe("useCard, previe:false", () => {
         ],
       });
       lesson.hand = ["a"];
-      lesson.idol.modifiers = [{ kind: "lifeConsumptionReduction", value: 1 }];
+      lesson.idol.modifiers = [
+        { kind: "lifeConsumptionReduction", value: 1, id: "x" },
+      ];
       const { updates } = useCard(lesson, 1, {
         selectedCardInHandIndex: 0,
         getRandom: () => 0,
@@ -1985,7 +1989,7 @@ describe("useCard, previe:false", () => {
           ],
         });
         lesson.hand = ["a"];
-        lesson.idol.modifiers = [{ kind: "doubleEffect", times: 1 }];
+        lesson.idol.modifiers = [{ kind: "doubleEffect", times: 1, id: "x" }];
         const { updates } = useCard(lesson, 1, {
           selectedCardInHandIndex: 0,
           getRandom: () => 0,
@@ -2272,43 +2276,10 @@ describe("useCard, previe:false", () => {
           modifier: {
             kind: "goodCondition",
             duration: 2,
+            id: expect.any(String),
           },
           reason: expect.any(Object),
         });
-      });
-      test("delayedEffectを追加する時、更新内容へidが設定されている", () => {
-        const lesson = createLessonForTest({
-          cards: [
-            {
-              id: "a",
-              definition: getCardDataById("joju"),
-              enabled: true,
-              enhanced: false,
-            },
-          ],
-        });
-        lesson.hand = ["a"];
-        const { updates } = useCard(lesson, 1, {
-          selectedCardInHandIndex: 0,
-          getRandom: () => 0,
-          idGenerator: () => "x",
-          preview: false,
-        });
-        const delayedEffectUpdates = updates.filter(
-          (e) => e.kind === "modifier" && e.modifier.kind === "delayedEffect",
-        ) as any;
-        expect(delayedEffectUpdates).toStrictEqual([
-          {
-            kind: "modifier",
-            modifier: {
-              kind: "delayedEffect",
-              delay: 1,
-              id: "x",
-              effect: expect.any(Object),
-            },
-            reason: expect.any(Object),
-          },
-        ]);
       });
     });
     describe("increaseRemainingTurns", () => {
@@ -2324,7 +2295,9 @@ describe("useCard, previe:false", () => {
           ],
         });
         lesson.hand = ["a"];
-        lesson.idol.modifiers = [{ kind: "positiveImpression", amount: 2 }];
+        lesson.idol.modifiers = [
+          { kind: "positiveImpression", amount: 2, id: "x" },
+        ];
         const { updates } = useCard(lesson, 1, {
           selectedCardInHandIndex: 0,
           getRandom: () => 0,
@@ -2366,8 +2339,8 @@ describe("useCard, previe:false", () => {
         });
         lesson.hand = ["a"];
         lesson.idol.modifiers = [
-          { kind: "focus", amount: 20 },
-          { kind: "positiveImpression", amount: 10 },
+          { kind: "focus", amount: 20, id: "x" },
+          { kind: "positiveImpression", amount: 10, id: "y" },
         ];
         const { updates } = useCard(lesson, 1, {
           selectedCardInHandIndex: 0,
@@ -2381,6 +2354,7 @@ describe("useCard, previe:false", () => {
           modifier: {
             kind: "positiveImpression",
             amount: 5,
+            id: expect.any(String),
           },
           reason: expect.any(Object),
         });
@@ -2536,7 +2510,7 @@ describe("useCard, previe:false", () => {
           ],
         });
         lesson.hand = ["a"];
-        lesson.idol.modifiers = [{ kind: "motivation", amount: 10 }];
+        lesson.idol.modifiers = [{ kind: "motivation", amount: 10, id: "x" }];
         const { updates } = useCard(lesson, 1, {
           selectedCardInHandIndex: 0,
           getRandom: () => 0,
@@ -2563,7 +2537,9 @@ describe("useCard, previe:false", () => {
           ],
         });
         lesson.hand = ["a"];
-        lesson.idol.modifiers = [{ kind: "positiveImpression", amount: 10 }];
+        lesson.idol.modifiers = [
+          { kind: "positiveImpression", amount: 10, id: "x" },
+        ];
         const { updates } = useCard(lesson, 1, {
           selectedCardInHandIndex: 0,
           getRandom: () => 0,
@@ -2594,7 +2570,7 @@ describe("useCard, previe:false", () => {
           clear: 1,
           perfect: 6,
         };
-        lesson.idol.modifiers = [{ kind: "motivation", amount: 5 }];
+        lesson.idol.modifiers = [{ kind: "motivation", amount: 5, id: "x" }];
         const { updates } = useCard(lesson, 1, {
           selectedCardInHandIndex: 0,
           getRandom: () => 0,
@@ -2789,6 +2765,7 @@ describe("useCard, previe:false", () => {
           modifier: {
             kind: "positiveImpression",
             amount: 3,
+            id: expect.any(String),
           },
           reason: expect.any(Object),
         },
@@ -2798,6 +2775,7 @@ describe("useCard, previe:false", () => {
             kind: "effectActivationUponCardUsage",
             cardKind: "mental",
             effect: expect.any(Object),
+            id: expect.any(String),
           },
           reason: expect.any(Object),
         },
@@ -2817,6 +2795,7 @@ describe("useCard, previe:false", () => {
           modifier: {
             kind: "positiveImpression",
             amount: 1,
+            id: expect.any(String),
           },
           reason: expect.any(Object),
         },
@@ -2868,6 +2847,7 @@ describe("useCard, previe:false", () => {
           modifier: {
             kind: "excellentCondition",
             duration: 3,
+            id: expect.any(String),
           },
           reason: expect.any(Object),
         },
@@ -2877,6 +2857,7 @@ describe("useCard, previe:false", () => {
             kind: "effectActivationUponCardUsage",
             cardKind: "active",
             effect: expect.any(Object),
+            id: expect.any(String),
           },
           reason: expect.any(Object),
         },

--- a/src/lesson-mutation.ts
+++ b/src/lesson-mutation.ts
@@ -147,8 +147,12 @@ export const createCardPlacementDiff = (
   };
 };
 
-/** アイドルがコスト分のリソースを持つかを検証する */
-export const validateCostComsumution = (
+/**
+ * アイドルがコスト分のリソースを持つかを検証する
+ *
+ * - TODO: 戻り値を errors にしないといけなさそう、プレビューや手札上に何のコストが足りなくて効果発動できないかが書いてあるので
+ */
+export const validateCostConsumution = (
   idol: Idol,
   cost: ActionCost,
 ): boolean => {
@@ -205,7 +209,7 @@ export const canUseCard = (
   cost: ActionCost,
   condition: CardUsageCondition | undefined,
 ): boolean => {
-  const costValidation = validateCostComsumution(lesson.idol, cost);
+  const costValidation = validateCostConsumution(lesson.idol, cost);
   if (!costValidation) {
     return false;
   }
@@ -275,7 +279,11 @@ export const canUseCard = (
   }
 };
 
-/** 各効果が適用できるかを判定する */
+/**
+ * 各効果が適用できるかを判定する
+ *
+ * - TODO: 戻り値を errors にする必要がありそう、プレビューや手札上に何が理由で効果が適用できないかが書いてあるので
+ */
 export const canApplyEffect = (
   lesson: Lesson,
   condition: EffectCondition,
@@ -343,12 +351,12 @@ export const canApplyEffect = (
 
 const calculateActualAndMaxComsumution = (
   resourceValue: number,
-  costValue: number,
+  costAbsValue: number,
 ) => {
   return {
-    actual: costValue > resourceValue ? -resourceValue : -costValue,
-    max: -costValue,
-    restCost: resourceValue > costValue ? 0 : costValue - resourceValue,
+    actual: Math.max(-resourceValue, -costAbsValue),
+    max: -costAbsValue,
+    restCost: Math.max(0, costAbsValue - resourceValue),
   };
 };
 
@@ -361,9 +369,15 @@ type CostConsumptionUpdateQueryDiff = Extract<
 /**
  * コスト消費を計算する
  *
- * - 消費分のコストが足りない場合は、最大値まで消費する差分を返す
+ * - 全体的に、 actual が実際にリソースを消費する差分、 max がコスト側から指定がある値、という形で返す
+ *   - つまり、消費分のコストが足りない場合に、actual と max に差が出る
+ *   - コストが払えない状況を考慮しているのは、コストが払えない状況でもスキルカード使用のプレビューはできるようにするため
+ * - 数値に対する `+ 0` は、`-0` を `0` に変換するため
+ * - 状態修正の場合、コストの対象となるリソースがない時は、0コストを返すのではなく全く結果を返さない
+ *   - まず、本家UIのスキルカード使用プレビューの仕様上、この状況の差分は全く画面に表示されないので、切実な必要がない
+ *   - そして、状態修正の新規追加で負の値があることを現状考慮していないので、その分の実装を省略するため
  */
-const calculateCostConsumption = (
+export const calculateCostConsumption = (
   idol: Idol,
   cost: ActionCost,
   idGenerator: IdGenerator,
@@ -380,54 +394,85 @@ const calculateCostConsumption = (
         restCost = result.restCost;
         updates.push({
           kind: "vitality",
-          actual: result.actual,
-          max: result.max,
+          actual: result.actual + 0,
+          max: result.max + 0,
         });
       }
       if (restCost > 0) {
         const result = calculateActualAndMaxComsumution(idol.life, restCost);
         updates.push({
           kind: "life",
-          actual: result.actual,
-          max: result.max,
+          actual: result.actual + 0,
+          max: result.max + 0,
         });
       }
       return updates;
     }
     case "life": {
+      const result = calculateActualAndMaxComsumution(idol.life, cost.value);
       return [
         {
           kind: "life",
-          actual: -cost.value,
-          max: -cost.value,
+          actual: result.actual + 0,
+          max: result.max + 0,
         },
       ];
     }
     case "focus":
     case "motivation":
     case "positiveImpression": {
-      return [
-        {
-          kind: "modifier",
-          modifier: {
-            kind: cost.kind,
-            amount: cost.value,
-            id: idGenerator(),
+      const id = idGenerator();
+      const sameKindModifier = idol.modifiers.find((e) => e.kind === cost.kind);
+      if (sameKindModifier && "amount" in sameKindModifier) {
+        const actual = Math.min(cost.value, sameKindModifier.amount);
+        return [
+          {
+            kind: "modifier",
+            actual: {
+              kind: cost.kind,
+              amount: -actual + 0,
+              id,
+              updateTargetId: sameKindModifier.id,
+            },
+            max: {
+              kind: cost.kind,
+              amount: -cost.value + 0,
+              id,
+              updateTargetId: sameKindModifier.id,
+            },
           },
-        },
-      ];
+        ];
+      } else {
+        // 結果を返す必要があるなら要考慮点がある、関数コメント参照
+        return [];
+      }
     }
     case "goodCondition": {
-      return [
-        {
-          kind: "modifier",
-          modifier: {
-            kind: cost.kind,
-            duration: cost.value,
-            id: idGenerator(),
+      const id = idGenerator();
+      const sameKindModifier = idol.modifiers.find((e) => e.kind === cost.kind);
+      if (sameKindModifier && "duration" in sameKindModifier) {
+        const actual = Math.min(cost.value, sameKindModifier.duration);
+        return [
+          {
+            kind: "modifier",
+            actual: {
+              kind: cost.kind,
+              duration: -actual + 0,
+              id,
+              updateTargetId: sameKindModifier.id,
+            },
+            max: {
+              kind: cost.kind,
+              duration: -cost.value + 0,
+              id,
+              updateTargetId: sameKindModifier.id,
+            },
           },
-        },
-      ];
+        ];
+      } else {
+        // 結果を返す必要があるなら要考慮点がある、関数コメント参照
+        return [];
+      }
     }
     default: {
       const unreachable: never = cost.kind;
@@ -495,6 +540,7 @@ export const calculatePerformingScoreEffect = (
   return diffs;
 };
 
+// TODO: 元気が上がらない状態修正の反映
 export const calculatePerformingVitalityEffect = (
   idol: Idol,
   query: VitalityUpdateQuery,
@@ -528,6 +574,7 @@ export const calculatePerformingVitalityEffect = (
  * - 1スキルカードや1Pアイテムが持つ効果リストに対して使う
  * - 本処理内では、レッスンその他の状況は変わらない前提
  *   - 「お嬢様の晴れ舞台」で、最初に加算される元気は、その後のパラメータ上昇の計算には含まれていない、などのことから
+ * - TODO: これは1効果だけの計算にして、スキルカード使用・Pアイテム用・Pドリンク用のラッパーにする方が良さそうかも
  */
 const activateEffects = (
   lesson: Lesson,
@@ -677,11 +724,27 @@ const activateEffects = (
         break;
       }
       case "getModifier": {
+        const id = idGenerator();
+        const sameKindModifier = lesson.idol.modifiers.find(
+          (e) => e.kind === effect.modifier.kind,
+        );
+        const isUpdate =
+          sameKindModifier !== undefined &&
+          effect.modifier.kind !== "delayedEffect" &&
+          effect.modifier.kind !== "doubleEffect" &&
+          effect.modifier.kind !== "effectActivationAtEndOfTurn" &&
+          effect.modifier.kind !== "effectActivationUponCardUsage";
         diffs.push({
           kind: "modifier",
-          modifier: {
+          actual: {
             ...effect.modifier,
-            id: idGenerator(),
+            id,
+            ...(isUpdate ? { updateTargetId: sameKindModifier.id } : {}),
+          },
+          max: {
+            ...effect.modifier,
+            id,
+            ...(isUpdate ? { updateTargetId: sameKindModifier.id } : {}),
           },
         });
         break;
@@ -699,14 +762,22 @@ const activateEffects = (
         );
         // 現在は、好印象に対してしか存在しない効果なので、そのこと前提で実装している
         if (modifier?.kind === "positiveImpression") {
+          const amount =
+            Math.ceil(modifier.amount * effect.multiplier) - modifier.amount;
+          const id = idGenerator();
           diffs.push({
             kind: "modifier",
-            modifier: {
+            actual: {
               kind: "positiveImpression",
-              amount:
-                Math.ceil(modifier.amount * effect.multiplier) -
-                modifier.amount,
-              id: idGenerator(),
+              amount,
+              id,
+              updateTargetId: modifier.id,
+            },
+            max: {
+              kind: "positiveImpression",
+              amount,
+              id,
+              updateTargetId: modifier.id,
             },
           });
         }
@@ -829,14 +900,22 @@ const activateDelayedEffectModifier = (
   if (modifier.delay === 1) {
     diffs = activateEffects(lesson, [modifier.effect], getRandom, idGenerator);
   }
+  const id = idGenerator();
   diffs = [
     ...diffs,
     {
       kind: "modifier",
-      modifier: {
+      actual: {
         ...modifier,
         delay: -1,
-        id: modifier.id,
+        id,
+        updateTargetId: modifier.id,
+      },
+      max: {
+        ...modifier,
+        delay: -1,
+        id,
+        updateTargetId: modifier.id,
       },
     },
   ];
@@ -1240,15 +1319,21 @@ export const useCard = (
     // 「次に使用するスキルカードの効果をもう1回発動」を消費
     //
     if (hasDoubleEffect && times === 1) {
+      const id = params.idGenerator();
       effectActivationUpdatesOnce = [
         ...effectActivationUpdatesOnce,
         createLessonUpdateQueryFromDiff(
           {
             kind: "modifier",
-            modifier: {
+            actual: {
               kind: "doubleEffect",
               times: 1,
-              id: params.idGenerator(),
+              id,
+            },
+            max: {
+              kind: "doubleEffect",
+              times: 1,
+              id,
             },
           },
           {

--- a/src/lesson-mutation.ts
+++ b/src/lesson-mutation.ts
@@ -366,6 +366,7 @@ type CostConsumptionUpdateQueryDiff = Extract<
 const calculateCostConsumption = (
   idol: Idol,
   cost: ActionCost,
+  idGenerator: IdGenerator,
 ): CostConsumptionUpdateQueryDiff[] => {
   switch (cost.kind) {
     case "normal": {
@@ -411,6 +412,7 @@ const calculateCostConsumption = (
           modifier: {
             kind: cost.kind,
             amount: cost.value,
+            id: idGenerator(),
           },
         },
       ];
@@ -422,6 +424,7 @@ const calculateCostConsumption = (
           modifier: {
             kind: cost.kind,
             duration: cost.value,
+            id: idGenerator(),
           },
         },
       ];
@@ -674,16 +677,12 @@ const activateEffects = (
         break;
       }
       case "getModifier": {
-        let modifier: Modifier = effect.modifier;
-        if (isDelayedEffectModifierType(modifier)) {
-          modifier = {
-            ...modifier,
-            id: idGenerator(),
-          };
-        }
         diffs.push({
           kind: "modifier",
-          modifier,
+          modifier: {
+            ...effect.modifier,
+            id: idGenerator(),
+          },
         });
         break;
       }
@@ -707,6 +706,7 @@ const activateEffects = (
               amount:
                 Math.ceil(modifier.amount * effect.multiplier) -
                 modifier.amount,
+              id: idGenerator(),
             },
           });
         }
@@ -1186,6 +1186,7 @@ export const useCard = (
   const costConsumptionUpdates: LessonUpdateQuery[] = calculateCostConsumption(
     newLesson.idol,
     calculateActualActionCost(cardContent.cost, newLesson.idol.modifiers),
+    params.idGenerator,
   ).map((diff) => ({
     ...diff,
     reason: {
@@ -1247,6 +1248,7 @@ export const useCard = (
             modifier: {
               kind: "doubleEffect",
               times: 1,
+              id: params.idGenerator(),
             },
           },
           {

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -417,6 +417,7 @@ describe("patchUpdates", () => {
               {
                 kind: "focus",
                 amount: 1,
+                id: "a",
               },
             ],
           },
@@ -427,6 +428,7 @@ describe("patchUpdates", () => {
             modifier: {
               kind: "goodCondition",
               duration: 2,
+              id: "b",
             },
             reason: {
               kind: "lessonStartTrigger",
@@ -439,10 +441,12 @@ describe("patchUpdates", () => {
           {
             kind: "focus",
             amount: 1,
+            id: "a",
           },
           {
             kind: "goodCondition",
             duration: 2,
+            id: "b",
           },
         ]);
       });
@@ -452,6 +456,7 @@ describe("patchUpdates", () => {
             modifiers: [
               {
                 kind: "effectActivationAtEndOfTurn",
+                id: "a",
               },
             ],
           },
@@ -461,6 +466,7 @@ describe("patchUpdates", () => {
             kind: "modifier",
             modifier: {
               kind: "effectActivationAtEndOfTurn",
+              id: "b",
             } as Extract<Modifier, { kind: "effectActivationAtEndOfTurn" }>,
             reason: {
               kind: "lessonStartTrigger",
@@ -472,9 +478,11 @@ describe("patchUpdates", () => {
         expect(lessonMock.idol.modifiers).toStrictEqual([
           {
             kind: "effectActivationAtEndOfTurn",
+            id: "a",
           },
           {
             kind: "effectActivationAtEndOfTurn",
+            id: "b",
           },
         ]);
       });
@@ -494,6 +502,7 @@ describe("patchUpdates", () => {
                   {
                     kind: modifierKind,
                     amount: 1,
+                    id: "a",
                   },
                 ],
               },
@@ -504,6 +513,7 @@ describe("patchUpdates", () => {
                 modifier: {
                   kind: modifierKind,
                   amount: 2,
+                  id: "b",
                 },
                 reason: {
                   kind: "lessonStartTrigger",
@@ -516,6 +526,7 @@ describe("patchUpdates", () => {
               {
                 kind: modifierKind,
                 amount: 3,
+                id: "a",
               },
             ]);
           });
@@ -526,6 +537,7 @@ describe("patchUpdates", () => {
                   {
                     kind: modifierKind,
                     amount: 5,
+                    id: "a",
                   },
                 ],
               },
@@ -536,6 +548,7 @@ describe("patchUpdates", () => {
                 modifier: {
                   kind: modifierKind,
                   amount: -1,
+                  id: "b",
                 },
                 reason: {
                   kind: "lessonStartTrigger",
@@ -548,6 +561,7 @@ describe("patchUpdates", () => {
               {
                 kind: modifierKind,
                 amount: 4,
+                id: "a",
               },
             ]);
           });
@@ -558,6 +572,7 @@ describe("patchUpdates", () => {
                   {
                     kind: modifierKind,
                     amount: 5,
+                    id: "a",
                   },
                 ],
               },
@@ -568,6 +583,7 @@ describe("patchUpdates", () => {
                 modifier: {
                   kind: modifierKind,
                   amount: -5,
+                  id: "b",
                 },
                 reason: {
                   kind: "lessonStartTrigger",
@@ -592,6 +608,7 @@ describe("patchUpdates", () => {
                   {
                     kind: modifierKind,
                     duration: 1,
+                    id: "a",
                   },
                 ],
               },
@@ -602,6 +619,7 @@ describe("patchUpdates", () => {
                 modifier: {
                   kind: modifierKind,
                   duration: 2,
+                  id: "b",
                 },
                 reason: {
                   kind: "lessonStartTrigger",
@@ -614,6 +632,7 @@ describe("patchUpdates", () => {
               {
                 kind: modifierKind,
                 duration: 3,
+                id: "a",
               },
             ]);
           });
@@ -624,6 +643,7 @@ describe("patchUpdates", () => {
                   {
                     kind: modifierKind,
                     duration: 5,
+                    id: "a",
                   },
                 ],
               },
@@ -634,6 +654,7 @@ describe("patchUpdates", () => {
                 modifier: {
                   kind: modifierKind,
                   duration: -1,
+                  id: "b",
                 },
                 reason: {
                   kind: "lessonStartTrigger",
@@ -646,6 +667,7 @@ describe("patchUpdates", () => {
               {
                 kind: modifierKind,
                 duration: 4,
+                id: "a",
               },
             ]);
           });
@@ -656,6 +678,7 @@ describe("patchUpdates", () => {
                   {
                     kind: modifierKind,
                     duration: 5,
+                    id: "a",
                   },
                 ],
               },
@@ -666,6 +689,7 @@ describe("patchUpdates", () => {
                 modifier: {
                   kind: modifierKind,
                   duration: -5,
+                  id: "b",
                 },
                 reason: {
                   kind: "lessonStartTrigger",
@@ -690,6 +714,7 @@ describe("patchUpdates", () => {
                   {
                     kind: modifierKind,
                     times: 1,
+                    id: "a",
                   },
                 ],
               },
@@ -700,6 +725,7 @@ describe("patchUpdates", () => {
                 modifier: {
                   kind: modifierKind,
                   times: 2,
+                  id: "b",
                 },
                 reason: {
                   kind: "lessonStartTrigger",
@@ -712,6 +738,7 @@ describe("patchUpdates", () => {
               {
                 kind: modifierKind,
                 times: 3,
+                id: "a",
               },
             ]);
           });
@@ -722,6 +749,7 @@ describe("patchUpdates", () => {
                   {
                     kind: modifierKind,
                     times: 5,
+                    id: "a",
                   },
                 ],
               },
@@ -732,6 +760,7 @@ describe("patchUpdates", () => {
                 modifier: {
                   kind: modifierKind,
                   times: -1,
+                  id: "b",
                 },
                 reason: {
                   kind: "lessonStartTrigger",
@@ -744,6 +773,7 @@ describe("patchUpdates", () => {
               {
                 kind: modifierKind,
                 times: 4,
+                id: "a",
               },
             ]);
           });
@@ -754,6 +784,7 @@ describe("patchUpdates", () => {
                   {
                     kind: modifierKind,
                     times: 5,
+                    id: "a",
                   },
                 ],
               },
@@ -764,6 +795,7 @@ describe("patchUpdates", () => {
                 modifier: {
                   kind: modifierKind,
                   times: -5,
+                  id: "b",
                 },
                 reason: {
                   kind: "lessonStartTrigger",
@@ -788,6 +820,7 @@ describe("patchUpdates", () => {
                   {
                     kind: modifierKind,
                     value: 1,
+                    id: "a",
                   },
                 ],
               },
@@ -798,6 +831,7 @@ describe("patchUpdates", () => {
                 modifier: {
                   kind: modifierKind,
                   value: 2,
+                  id: "b",
                 },
                 reason: {
                   kind: "lessonStartTrigger",
@@ -810,6 +844,7 @@ describe("patchUpdates", () => {
               {
                 kind: modifierKind,
                 value: 3,
+                id: "a",
               },
             ]);
           });
@@ -820,6 +855,7 @@ describe("patchUpdates", () => {
                   {
                     kind: modifierKind,
                     value: 5,
+                    id: "a",
                   },
                 ],
               },
@@ -830,6 +866,7 @@ describe("patchUpdates", () => {
                 modifier: {
                   kind: modifierKind,
                   value: -1,
+                  id: "b",
                 },
                 reason: {
                   kind: "lessonStartTrigger",
@@ -842,6 +879,7 @@ describe("patchUpdates", () => {
               {
                 kind: modifierKind,
                 value: 4,
+                id: "a",
               },
             ]);
           });
@@ -852,6 +890,7 @@ describe("patchUpdates", () => {
                   {
                     kind: modifierKind,
                     value: 5,
+                    id: "a",
                   },
                 ],
               },
@@ -862,6 +901,7 @@ describe("patchUpdates", () => {
                 modifier: {
                   kind: modifierKind,
                   value: -5,
+                  id: "b",
                 },
                 reason: {
                   kind: "lessonStartTrigger",
@@ -883,6 +923,7 @@ describe("patchUpdates", () => {
               {
                 kind: "doubleEffect",
                 times: 1,
+                id: "a",
               },
             ],
           },
@@ -893,6 +934,7 @@ describe("patchUpdates", () => {
             modifier: {
               kind: "doubleEffect",
               times: 1,
+              id: "b",
             },
             reason: {
               kind: "lessonStartTrigger",
@@ -905,10 +947,12 @@ describe("patchUpdates", () => {
           {
             kind: "doubleEffect",
             times: 1,
+            id: "a",
           },
           {
             kind: "doubleEffect",
             times: 1,
+            id: "b",
           },
         ]);
       });
@@ -919,14 +963,17 @@ describe("patchUpdates", () => {
               {
                 kind: "doubleEffect",
                 times: 1,
+                id: "a",
               },
               {
                 kind: "focus",
                 amount: 1,
+                id: "b",
               },
               {
                 kind: "doubleEffect",
                 times: 1,
+                id: "c",
               },
             ],
           },
@@ -937,6 +984,7 @@ describe("patchUpdates", () => {
             modifier: {
               kind: "doubleEffect",
               times: -1,
+              id: "d",
             },
             reason: {
               kind: "lessonStartTrigger",
@@ -949,10 +997,12 @@ describe("patchUpdates", () => {
           {
             kind: "focus",
             amount: 1,
+            id: "b",
           },
           {
             kind: "doubleEffect",
             times: 1,
+            id: "c",
           },
         ]);
       });

--- a/src/models.ts
+++ b/src/models.ts
@@ -37,6 +37,7 @@ import {
   LessonUpdateQuery,
   LessonUpdateQueryDiff,
   Modifier,
+  ModifierDefinition,
 } from "./types";
 import { createIdGenerator, shuffleArray } from "./utils";
 
@@ -226,7 +227,7 @@ export const calculateActualRemainingTurns = (lesson: Lesson): number =>
 /** 「消費体力減少」・「消費体力削減」・「消費体力増加」を反映したコストを返す */
 export const calculateActualActionCost = (
   cost: ActionCost,
-  modifiers: Modifier[],
+  modifiers: ModifierDefinition[],
 ): ActionCost => {
   switch (cost.kind) {
     case "focus":

--- a/src/models.ts
+++ b/src/models.ts
@@ -323,119 +323,117 @@ export const patchUpdates = (
         break;
       }
       case "modifier": {
-        let newModifiers: Modifier[] = newLesson.idol.modifiers;
-        const sameKindIndex = newLesson.idol.modifiers.findIndex(
-          (e) => e.kind === update.modifier.kind,
-        );
-        // 同種の状態修正がない場合は新規追加、または特殊な状態修正の場合は新規追加
-        if (
-          sameKindIndex === -1 ||
-          update.modifier.kind === "effectActivationAtEndOfTurn" ||
-          update.modifier.kind === "effectActivationUponCardUsage"
-        ) {
-          newModifiers = [...newModifiers, update.modifier];
-        } else if (update.modifier.kind === "delayedEffect") {
-          if (update.modifier.delay >= 1) {
-            newModifiers = [...newModifiers, update.modifier];
-          } else {
-            newModifiers = newModifiers
-              .map((modifier) =>
-                isDelayedEffectModifierType(modifier) &&
-                isDelayedEffectModifierType(update.modifier) &&
-                update.modifier.id === modifier.id
-                  ? {
-                      ...modifier,
-                      delay: modifier.delay - 1,
-                    }
-                  : modifier,
-              )
-              .filter(
-                (modifier) =>
-                  !isDelayedEffectModifierType(modifier) || modifier.delay >= 1,
-              );
-          }
-        } else if (update.modifier.kind === "doubleEffect") {
-          if (update.modifier.times === 1) {
-            newModifiers = [...newModifiers, update.modifier];
-          } else {
-            const foundIndex = newModifiers.findIndex(
-              (e) => e.kind === "doubleEffect",
-            );
-            const tmp = newModifiers.slice();
-            tmp.splice(foundIndex, 1);
-            newModifiers = tmp;
-          }
+        const updateTargetId = update.actual.updateTargetId;
+        let newModifiers = newLesson.idol.modifiers;
+        if (updateTargetId === undefined) {
+          // 新規追加で負の値が入ることは想定していない
+          newModifiers = [...newModifiers, update.actual];
         } else {
-          const updateModifierKind = update.modifier.kind;
-          newModifiers = newModifiers.map((modifier) => {
-            let newModifier: Modifier = modifier;
-            switch (updateModifierKind) {
-              // duration の設定もあるが、現在は常に 1 なので無視する
-              case "additionalCardUsageCount": {
-                if (modifier.kind === update.modifier.kind) {
-                  newModifier = {
-                    ...modifier,
-                    amount: modifier.amount + update.modifier.amount,
-                  };
-                }
-                break;
-              }
-              case "debuffProtection": {
-                if (modifier.kind === update.modifier.kind) {
-                  newModifier = {
-                    ...modifier,
-                    times: modifier.times + update.modifier.times,
-                  };
-                }
-                break;
-              }
-              case "doubleLifeConsumption":
-              case "excellentCondition":
-              case "halfLifeConsumption":
-              case "goodCondition":
-              case "mightyPerformance":
-              case "noVitalityIncrease": {
-                if (modifier.kind === update.modifier.kind) {
-                  newModifier = {
-                    ...modifier,
-                    duration: modifier.duration + update.modifier.duration,
-                  };
-                }
-                break;
-              }
-              case "focus":
-              case "motivation":
-              case "positiveImpression": {
-                if (modifier.kind === update.modifier.kind) {
-                  newModifier = {
-                    ...modifier,
-                    amount: modifier.amount + update.modifier.amount,
-                  };
-                }
-                break;
-              }
-              case "lifeConsumptionReduction": {
-                if (modifier.kind === update.modifier.kind) {
-                  newModifier = {
-                    ...modifier,
-                    value: modifier.value + update.modifier.value,
-                  };
-                }
-                break;
-              }
-              default:
-                const unreachable: never = updateModifierKind;
-                throw new Error(`Unreachable statement`);
-            }
-            return newModifier;
-          });
-          newModifiers = newModifiers.filter(
-            (modifier) =>
-              ("amount" in modifier && modifier.amount > 0) ||
-              ("duration" in modifier && modifier.duration > 0) ||
-              ("times" in modifier && modifier.times > 0) ||
-              ("value" in modifier && modifier.value > 0),
+          const targetedModifier = newLesson.idol.modifiers.find(
+            (e) => e.id === updateTargetId,
           );
+          if (targetedModifier === undefined) {
+            throw new Error(`Targeted modifier not found: ${updateTargetId}`);
+          }
+          let newTargetedModifier = targetedModifier;
+          const updateModifierKind = update.actual.kind;
+          switch (updateModifierKind) {
+            // duration の設定もあるが、現在は常に 1 なので無視する
+            case "additionalCardUsageCount": {
+              if (update.actual.kind === newTargetedModifier.kind) {
+                newTargetedModifier = {
+                  ...newTargetedModifier,
+                  amount: newTargetedModifier.amount + update.actual.amount,
+                };
+              }
+              break;
+            }
+            case "debuffProtection": {
+              if (update.actual.kind === newTargetedModifier.kind) {
+                newTargetedModifier = {
+                  ...newTargetedModifier,
+                  times: newTargetedModifier.times + update.actual.times,
+                };
+              }
+              break;
+            }
+            case "delayedEffect": {
+              if (update.actual.kind === newTargetedModifier.kind) {
+                newTargetedModifier = {
+                  ...newTargetedModifier,
+                  delay: newTargetedModifier.delay + update.actual.delay,
+                };
+              }
+              break;
+            }
+            // 合算できないので、この既存状態修正を指定した処理を行う時は、常に削除の意味になる
+            case "doubleEffect": {
+              if (update.actual.kind === newTargetedModifier.kind) {
+                newTargetedModifier = {
+                  ...newTargetedModifier,
+                  times: 0,
+                };
+              }
+              break;
+            }
+            case "doubleLifeConsumption":
+            case "excellentCondition":
+            case "goodCondition":
+            case "halfLifeConsumption":
+            case "mightyPerformance":
+            case "noVitalityIncrease": {
+              if (update.actual.kind === newTargetedModifier.kind) {
+                newTargetedModifier = {
+                  ...newTargetedModifier,
+                  duration:
+                    newTargetedModifier.duration + update.actual.duration,
+                };
+              }
+              break;
+            }
+            case "focus":
+            case "motivation":
+            case "positiveImpression": {
+              if (update.actual.kind === newTargetedModifier.kind) {
+                newTargetedModifier = {
+                  ...newTargetedModifier,
+                  amount: newTargetedModifier.amount + update.actual.amount,
+                };
+              }
+              break;
+            }
+            case "lifeConsumptionReduction": {
+              if (update.actual.kind === newTargetedModifier.kind) {
+                newTargetedModifier = {
+                  ...newTargetedModifier,
+                  value: newTargetedModifier.value + update.actual.value,
+                };
+              }
+              break;
+            }
+            // 常に新規追加で、かつ削除できないので、ここを通ることはない
+            case "effectActivationAtEndOfTurn":
+            case "effectActivationUponCardUsage": {
+              throw new Error(
+                `Unexpected modifier kind: ${updateModifierKind}`,
+              );
+            }
+            default:
+              const unreachable: never = updateModifierKind;
+              throw new Error(`Unreachable statement`);
+          }
+          newModifiers = newModifiers
+            .map((modifier) =>
+              modifier.id === updateTargetId ? newTargetedModifier : modifier,
+            )
+            .filter(
+              (modifier) =>
+                ("amount" in modifier && modifier.amount > 0) ||
+                ("delay" in modifier && modifier.delay > 0) ||
+                ("duration" in modifier && modifier.duration > 0) ||
+                ("times" in modifier && modifier.times > 0) ||
+                ("value" in modifier && modifier.value > 0),
+            );
         }
         newLesson = {
           ...newLesson,

--- a/src/text-generation.ts
+++ b/src/text-generation.ts
@@ -5,7 +5,7 @@ import type {
   CardUsageCondition,
   Effect,
   EffectCondition,
-  Modifier,
+  ModifierDefinition,
   ProducerItemContentDefinition,
   ProducerItemTrigger,
   RangedNumber,
@@ -120,7 +120,7 @@ const generateModifierKindText = (
 /**
  * 一つの状態修正を表現したテキストを生成する
  */
-const generateModifierText = (modifier: Modifier): string => {
+const generateModifierText = (modifier: ModifierDefinition): string => {
   switch (modifier.kind) {
     case "additionalCardUsageCount":
       return `${kwd("additionalCardUsageCount")}+${modifier.amount}`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -139,8 +139,8 @@ export type ModifierDefinition =
        * - この状態修正は合算されない、例えば「国民的アイドル」を2回連続で使うと、2つの状態修正として表示される
        */
       kind: "doubleEffect";
-      /** 状態修正更新クエリとして使用する際に、1 なら追加、-1 は削除、の意味 */
-      times: 1 | -1;
+      /** 状態修正更新クエリとして使用する際に、1 なら追加、-1 は削除、の意味。0 は計算中の削除待ち状態であり得る。 */
+      times: 1 | 0 | -1;
     }
   | {
       /** 「消費体力増加{duration}ターン」 */
@@ -226,16 +226,16 @@ export type ModifierDefinition =
  * 状態修正
  *
  * - レッスン中に画面左上に表示されるアイコン群のことを、状態修正(modifier)と呼ぶ
- * - 現在の状況を表現するのに使うのと共に、加算時の更新要求を表現するのにも使う
- *   - 加算の表現は、単に加算するしかできないので、その内無理になるかもしれない。元気は VitalityUpdateQuery が必要になった。
- *   - 減算の表現は含まない、減算は ActionCost 側で表現する
+ * - 現在の状況を表現するのに使うのと共に、更新を表現するのにも使う
  * - 付与された順番で左側のアイコンとアイコンタップ時の説明リストに表示される
  *   - 「スキルカード使用数+1」のアイコンは別の場所に表示されるが、説明リストには追加された順に表示されている
  * - 種類は名詞句で表現する、原文が名詞だから
- * - TODO: 状態そのものの表現と更新差分の表現を1つの構造で兼用しているので拡張性が危ない、例えば delayedEffect の id や doubleEffect の times などがおかしい
  */
 export type Modifier = ModifierDefinition & {
+  /** 全てのインスタンスで一意のID */
   id: string;
+  /** 既存インスタンスの更新時にのみ存在する、対象のID */
+  updateTargetId?: string;
 };
 
 /**
@@ -1148,11 +1148,10 @@ export type LessonUpdateQueryDiff =
   | {
       /**
        * 状態修正の差分
-       *
-       * - life や vitality とは異なり、現状使うとこがなさそうなので max は付与していない
        */
       kind: "modifier";
-      modifier: Modifier;
+      actual: Modifier;
+      max: Modifier;
     }
   | {
       kind: "remainingTurns";

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,18 +75,11 @@ export type VitalityUpdateQuery = {
 };
 
 /**
- * 状態修正
+ * 状態修正定義
  *
- * - レッスン中に画面左上に表示されるアイコン群のことを、状態修正(modifier)と呼ぶ
- * - 現在の状況を表現するのに使うのと共に、加算時の更新要求を表現するのにも使う
- *   - 加算の表現は、単に加算するしかできないので、その内無理になるかもしれない。元気は VitalityUpdateQuery が必要になった。
- *   - 減算の表現は含まない、減算は ActionCost 側で表現する
- * - 付与された順番で左側のアイコンとアイコンタップ時の説明リストに表示される
- *   - 「スキルカード使用数+1」のアイコンは別の場所に表示されるが、説明リストには追加された順に表示されている
- * - 種類は名詞句で表現する、原文が名詞だから
- * - TODO: データ定義・インスタンス・インスタンスへの更新クエリの3役割を1つの構造に強引にまとめているので拡張性が危ない、例えば delayedEffect の id や doubleEffect の times などがおかしい
+ * - Modifier をデータ定義で行う時の形式
  */
-export type Modifier =
+export type ModifierDefinition =
   | {
       /**
        * 「スキルカード使用数追加+{amount}」
@@ -135,8 +128,6 @@ export type Modifier =
         Effect,
         { kind: "drawCards" | "enhanceHand" | "perform" }
       >;
-      /** レッスン内のみ存在して変更する値を指定するのに使う、アイドルの状態修正リスト内で一意のID */
-      id?: string;
     }
   | {
       /**
@@ -230,6 +221,22 @@ export type Modifier =
       kind: "positiveImpression";
       amount: number;
     };
+
+/**
+ * 状態修正
+ *
+ * - レッスン中に画面左上に表示されるアイコン群のことを、状態修正(modifier)と呼ぶ
+ * - 現在の状況を表現するのに使うのと共に、加算時の更新要求を表現するのにも使う
+ *   - 加算の表現は、単に加算するしかできないので、その内無理になるかもしれない。元気は VitalityUpdateQuery が必要になった。
+ *   - 減算の表現は含まない、減算は ActionCost 側で表現する
+ * - 付与された順番で左側のアイコンとアイコンタップ時の説明リストに表示される
+ *   - 「スキルカード使用数+1」のアイコンは別の場所に表示されるが、説明リストには追加された順に表示されている
+ * - 種類は名詞句で表現する、原文が名詞だから
+ * - TODO: 状態そのものの表現と更新差分の表現を1つの構造で兼用しているので拡張性が危ない、例えば delayedEffect の id や doubleEffect の times などがおかしい
+ */
+export type Modifier = ModifierDefinition & {
+  id: string;
+};
 
 /**
  * 効果発動条件
@@ -378,7 +385,7 @@ export type Effect = (
        * - 1行の効果説明内で複数の状態変化を付与するスキルカードはなかった
        */
       kind: "getModifier";
-      modifier: Modifier;
+      modifier: ModifierDefinition;
     }
   | {
       /**


### PR DESCRIPTION
- やったこと
  - `Modifier` をデータ定義上で使う部分の ModifierDefinition と分離した
  - `"modifier"` の更新クエリは、 `updateTargetId` の有無で、新規追加か既存更新かを判別できるようにした
  - `"modifier"` の更新クエリにも、他の `"life"` などと同じように、 `actual` / `max` の両方を生成するようにした
  - `Modifier` をコストとして消費した時、リソースよりも多い状況が例外にならないように考慮した
    - スキルカード使用プレビューのためにこれが欲しかったのが当初の目的
    - 他の変更もプレビューや手札一覧のために必要なものを整えるため