### PR TITLE
消費体力削減の効果間違いを修正

### DIFF
--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -243,6 +243,16 @@ describe("calculateActualActionCost", () => {
     },
     {
       args: [
+        { kind: "normal", value: 2 },
+        [
+          { kind: "lifeConsumptionReduction", value: 1 },
+          { kind: "doubleLifeConsumption", duration: 1 },
+        ],
+      ],
+      expected: { kind: "normal", value: 3 },
+    },
+    {
+      args: [
         { kind: "life", value: 1 },
         [{ kind: "lifeConsumptionReduction", value: 1 }],
       ],

--- a/src/models.ts
+++ b/src/models.ts
@@ -234,12 +234,14 @@ export const calculateActualActionCost = (
         modifiers.find((e) => e.kind === "halfLifeConsumption") !== undefined;
       const hasDoubleLifeConsumption =
         modifiers.find((e) => e.kind === "doubleLifeConsumption") !== undefined;
-      const value = Math.max(cost.value - lifeConsumptionReductionValue, 0);
       let rate = hasDoubleLifeConsumption ? 2 : 1;
       rate = rate / (halfLifeConsumption ? 2 : 1);
       return {
         kind: cost.kind,
-        value: Math.ceil(value * rate),
+        value: Math.max(
+          Math.ceil(cost.value * rate) - lifeConsumptionReductionValue,
+          0,
+        ),
       };
     }
     default: {


### PR DESCRIPTION
- 今の実装
  - 消費体力削減を減算してから、消費体力増加でコストを倍する
- 正しい仕様
  - 消費体力増加でコストを倍してから、消費体力削減を減算する