### PR TITLE
previewCardPlayを調整

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@
 // TODO: コンテスト
 
 import {
+  CardPlayPreviewDisplay,
   EncouragementDisplay,
   Lesson,
   LessonGamePlay,
@@ -50,6 +51,7 @@ import {
 } from "./models";
 import {
   generateCardDescription,
+  generateCardName,
   generateEffectText,
   generateProducerItemDescription,
   idolParameterKindLabels,
@@ -480,15 +482,16 @@ export const isTurnEnded = (lessonGamePlay: LessonGamePlay): boolean => {
  * スキルカード使用のプレビューを表示するための情報を返す
  *
  * - 本家のプレビュー仕様
- *   - 体力・元気
+ *   - 体力・元気の差分
  *     - 効果反映後の値に変わり、その近くに差分アイコンが +n/-n で表示される
  *     - 差分は実際に変化した値を表示する、例えば、結果的に値の変更がない場合は何も表示されない
- *   - 状態修正差分
+ *   - 状態修正の差分
  *     - 新規: スキルカード追加使用など一部のものを除いて、左側の状態修正リストの末尾へ追加
  *     - 既存: 差分がある状態修正アイコンに差分適用後の値を表示し、その右に差分アイコンを表示する
  *     - スキルカード追加使用、次に使用するスキルカードの効果をもう1回発動、など、差分アイコンが表示されないものもある
  *   - スキルカード詳細ポップアップ
- *     - 全ての項目が、各効果による変化前のデータ定義時の値
+ *     - 全ての項目が、各効果による変化前のデータ定義時の値、強化段階のみ反映される
+ *       - 例えば、「消費体力減少」が付与されていても、コストは半分にならない
  *   - プレビュー時には、選択したスキルカードの効果のみ反映される
  *     - 例えば、「ワクワクが止まらない」の状態修正が付与されている時に、メンタルスキルカードを選択しても、その分は反映されない
  *       - 参考動画: https://youtu.be/7hbRaIYE_ZI?si=Jd5JYrOVCJZZPp7i&t=214
@@ -503,7 +506,7 @@ export const isTurnEnded = (lessonGamePlay: LessonGamePlay): boolean => {
 export const previewCardPlay = (
   lessonGamePlay: LessonGamePlay,
   selectedCardInHandIndex: number,
-): { cardDescription: string; updates: LessonUpdateQuery[] } => {
+): CardPlayPreviewDisplay => {
   const lesson = patchUpdates(
     lessonGamePlay.initialLesson,
     lessonGamePlay.updates,
@@ -533,6 +536,8 @@ export const previewCardPlay = (
   });
   return {
     cardDescription,
+    cardName: generateCardName(card),
+    cardCost: cardContent.cost,
     updates,
   };
 };

--- a/src/lesson-mutation.ts
+++ b/src/lesson-mutation.ts
@@ -40,6 +40,7 @@ import {
   patchUpdates,
   prepareCardsForLesson,
 } from "./models";
+import { generateCardName } from "./text-generation";
 import { shuffleArray, validateNumberInRange } from "./utils";
 
 /** 主に型都合のユーティリティ処理 */
@@ -1321,7 +1322,7 @@ export const summarizeCardInHand = (
     cost: calculateActualActionCost(cardContent.cost, lesson.idol.modifiers),
     effects,
     enhancements: card.enhancements,
-    name: card.original.data.name + "+".repeat(card.enhancements.length),
+    name: generateCardName(card),
     playable: canUseCard(lesson, cardContent.cost, cardContent.condition),
     scores,
     vitality,

--- a/src/text-generation.test.ts
+++ b/src/text-generation.test.ts
@@ -1,3 +1,4 @@
+import type { Card, CardData, ProducerItemData } from "./types";
 import {
   findCardDataById,
   getCardContentDataList,
@@ -7,13 +8,13 @@ import { getProducerItemDataById } from "./data/producer-items";
 import {
   generateActionCostText,
   generateCardDescription,
+  generateCardName,
   generateCardUsageConditionText,
   generateEffectText,
   generateProducerItemDescription,
   generateProducerItemTriggerAndConditionText,
   globalDataKeywords,
 } from "./text-generation";
-import type { CardData, ProducerItemData } from "./types";
 
 describe("globalDataKeywords", () => {
   describe("`cards`のキーがデータ定義のidに存在する", () => {
@@ -25,7 +26,67 @@ describe("globalDataKeywords", () => {
     });
   });
 });
-
+describe("generateCardName", () => {
+  const testCases: Array<{
+    args: Parameters<typeof generateCardName>;
+    expected: ReturnType<typeof generateCardName>;
+  }> = [
+    {
+      args: [
+        {
+          original: {
+            data: getCardDataById("apirunokihon"),
+          },
+          enhancements: [] as any,
+        } as Card,
+      ],
+      expected: "アピールの基本",
+    },
+    {
+      args: [
+        {
+          original: {
+            data: getCardDataById("apirunokihon"),
+          },
+          enhancements: [{ kind: "original" }],
+        } as Card,
+      ],
+      expected: "アピールの基本+",
+    },
+    {
+      args: [
+        {
+          original: {
+            data: getCardDataById("apirunokihon"),
+          },
+          enhancements: [{ kind: "effect" }, { kind: "lessonSupport" }],
+        } as Card,
+      ],
+      expected: "アピールの基本++",
+    },
+    {
+      args: [
+        {
+          original: {
+            data: getCardDataById("apirunokihon"),
+          },
+          enhancements: [
+            { kind: "effect" },
+            { kind: "lessonSupport" },
+            { kind: "lessonSupport" },
+          ],
+        } as Card,
+      ],
+      expected: "アピールの基本+++",
+    },
+  ];
+  test.each(testCases)(
+    '$args.0.enhancements => "$expected"',
+    ({ args, expected }) => {
+      expect(generateCardName(...args)).toBe(expected);
+    },
+  );
+});
 describe("generateEffectText", () => {
   const testCases: Array<{
     args: Parameters<typeof generateEffectText>;
@@ -505,7 +566,6 @@ describe("generateEffectText", () => {
     expect(generateEffectText(...args)).toBe(expected);
   });
 });
-
 describe("generateCardUsageConditionText", () => {
   const testCases: Array<{
     args: Parameters<typeof generateCardUsageConditionText>;
@@ -556,7 +616,6 @@ describe("generateCardUsageConditionText", () => {
     expect(generateCardUsageConditionText(...args)).toBe(expected);
   });
 });
-
 describe("generateActionCostText", () => {
   const testCases: Array<{
     args: Parameters<typeof generateActionCostText>;
@@ -579,7 +638,6 @@ describe("generateActionCostText", () => {
     expect(generateActionCostText(...args)).toBe(expected);
   });
 });
-
 describe("generateCardDescription", () => {
   const testCases: Array<{
     cardId: CardData["id"];
@@ -806,7 +864,6 @@ describe("generateCardDescription", () => {
     ).toBe(expected);
   });
 });
-
 describe("generateProducerItemTriggerAndConditionText", () => {
   const testCases: Array<{
     args: Parameters<typeof generateProducerItemTriggerAndConditionText>;
@@ -1018,7 +1075,6 @@ describe("generateProducerItemTriggerAndConditionText", () => {
     expect(generateProducerItemTriggerAndConditionText(...args)).toBe(expected);
   });
 });
-
 describe("generateProducerItemDescription", () => {
   const testCases: Array<{
     expected: ReturnType<typeof generateProducerItemDescription>;

--- a/src/text-generation.ts
+++ b/src/text-generation.ts
@@ -11,6 +11,7 @@
 
 import type {
   ActionCost,
+  Card,
   CardData,
   CardContentData,
   CardUsageCondition,
@@ -120,6 +121,12 @@ const cardKwd = (key: string): string => {
   }
   throw new Error(`Global data keyword not found: ${key}`);
 };
+
+/**
+ * スキルカード名を生成する
+ */
+export const generateCardName = (card: Card): string =>
+  card.original.data.name + "+".repeat(card.enhancements.length);
 
 /**
  * 状態修正種別のみからキーワードを生成する

--- a/src/text-generation.ts
+++ b/src/text-generation.ts
@@ -4,8 +4,9 @@
  * - スキルカードやPアイテムの効果説明欄のテキストなどを動的に生成する
  *   - 基本的には、P図鑑の表記を参考にしている
  * - データとして定義する手段もあると思うが、少なくとも以下の点で動的な生成処理が必要になる
- *   - スキルカード使用プレビューでは、強化段階による効果の変化を反映する必要がある、また「レッスン中1回」が「試験・ステージ中1回」へ変化する
+ *   - スキルカード使用プレビューでは、強化段階による効果の変化を反映する必要がある、また「レッスン中」という文言が「試験・ステージ中」へ変化する
  * - もし、多言語対応をするなら、このモジュール全体を言語別に作る必要がありそう
+ * - TODO: 「レッスン中」を「試験・ステージ中」へ変化できるようにする
  */
 
 import type {
@@ -92,7 +93,6 @@ const globalKeywords = {
   noVitalityIncrease: metaModifierDictioanry.noVitalityIncrease.label,
   nonDuplicative: "重複不可",
   positiveImpression: metaModifierDictioanry.positiveImpression.label,
-  // TODO: 状況により「試験・ステージ中1回」に変化する、少なくともアイドルの道だとそうだった
   usableOncePerLesson: "レッスン中1回",
   vitality: "元気",
 } as const satisfies Record<string, string>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1591,3 +1591,13 @@ export type LessonDisplay = {
   turns: TurnDisplay[];
   vitality: Idol["vitality"];
 };
+
+/**
+ * スキルカード使用プレビューの表示用情報
+ */
+export type CardPlayPreviewDisplay = {
+  cardCost: ActionCost;
+  cardDescription: string;
+  cardName: string;
+  updates: LessonUpdateQuery[];
+};


### PR DESCRIPTION
- プレイ再現の結合テストであまり確認しないもののみ、個別でテストを書く、の一環で previewCardPlay を調整した
  - `skipTurn` も確認しようとしてたけど、これは好印象系の結合テストを足して、そこで確認した方が良さそうだった
  - そして、他になかった