### PR TITLE
一部の箇所でconstのデータのIDを型として利用する

### DIFF
--- a/src/data/cards.ts
+++ b/src/data/cards.ts
@@ -100,7 +100,7 @@ export const compareDeckOrder = (a: CardData, b: CardData) => {
  *       - kind > *Kind > それ以外をアルファベット順
  * - TODO: eslint
  */
-export const cards: CardData[] = [
+const cardsAsConst = [
   {
     id: "apirunokihon",
     name: "アピールの基本",
@@ -7321,4 +7321,8 @@ export const cards: CardData[] = [
       },
     ],
   },
-];
+] as const satisfies CardData[];
+
+export type CardDataId = (typeof cardsAsConst)[number]["id"];
+
+export const cards: CardData[] = cardsAsConst;

--- a/src/data/idols.ts
+++ b/src/data/idols.ts
@@ -21,7 +21,7 @@ export const getIdolDataById = (id: IdolData["id"]): IdolData => {
  * - TODO: eslint
  * - TODO: 咲季のBoom Boom Pow以降のキャラを追加する
  */
-export const idols: IdolData[] = [
+const idolsAsConst: IdolData[] = [
   {
     id: "hanamisaki-ssr-1",
     characterId: "hanamisaki",
@@ -382,4 +382,8 @@ export const idols: IdolData[] = [
     specificProducerItemId: "tekunodoggu",
     title: "学園生活",
   },
-];
+] as const satisfies IdolData[];
+
+export type IdolDataId = (typeof idolsAsConst)[number]["id"];
+
+export const idols: IdolData[] = idolsAsConst;

--- a/src/data/producer-items.ts
+++ b/src/data/producer-items.ts
@@ -38,7 +38,7 @@ export const getProducerItemDataById = (
  * - Pアイテムは、スキルカードと異なり、未強化と強化済みが別レコードとして図鑑の一覧に並んでいる。今のところ影響はないが、本家のデータ構造はスキルカードと異なるのかもしれない。
  * - TODO: eslint
  */
-export const producerItems: ProducerItemData[] = [
+const producerItemsAsConst = [
   {
     id: "bakuonraion",
     name: "ばくおんライオン",
@@ -1288,4 +1288,8 @@ export const producerItems: ProducerItemData[] = [
       },
     },
   },
-];
+] as const satisfies ProducerItemData[];
+
+export type ProducerItemDataId = (typeof producerItems)[number]["id"];
+
+export const producerItems: ProducerItemData[] = producerItemsAsConst;

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,21 +14,22 @@
 // TODO: コンテスト
 
 import {
-  CardData,
   Encouragement,
   Idol,
-  IdolData,
   Lesson,
   GamePlay,
   LessonUpdateQuery,
   MemoryEffect,
-  ProducerItemData,
   CardInProduction,
   ProducerItemInProduction,
   IdolInProduction,
 } from "./types";
-import { getCardDataById } from "./data/cards";
-import { getProducerItemDataById } from "./data/producer-items";
+import { type CardDataId, getCardDataById } from "./data/cards";
+import { type IdolDataId } from "./data/idols";
+import {
+  type ProducerItemDataId,
+  getProducerItemDataById,
+} from "./data/producer-items";
 import {
   activateEffectsOnLessonStart,
   activateEffectsOnTurnEnd,
@@ -113,13 +114,13 @@ export * from "./utils";
 export const initializeGamePlay = (params: {
   cards: Array<{
     enhanced?: CardInProduction["enhanced"];
-    id: CardData["id"];
+    id: CardDataId;
     /** テスト用、本来知る必要がない内部的なIDを指定する */
     testId?: CardInProduction["id"];
   }>;
   clearScoreThresholds?: Lesson["clearScoreThresholds"];
   encouragements?: Encouragement[];
-  idolDataId: IdolData["id"];
+  idolDataId: IdolDataId;
   idolSpecificCardTestId?: CardInProduction["id"];
   ignoreIdolParameterKindConditionAfterClearing?: Lesson["ignoreIdolParameterKindConditionAfterClearing"];
   life?: IdolInProduction["life"];
@@ -127,7 +128,7 @@ export const initializeGamePlay = (params: {
   memoryEffects?: MemoryEffect[];
   producerItems: Array<{
     enhanced?: ProducerItemInProduction["enhanced"];
-    id: ProducerItemData["id"];
+    id: ProducerItemDataId;
   }>;
   scoreBonus?: Idol["scoreBonus"];
   specialTrainingLevel?: number | undefined;

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -4,18 +4,16 @@ import type {
   Lesson,
   GamePlay,
   ProducerItemInProduction,
-} from "./index";
-import {
-  createIdGenerator,
-  createIdolInProduction,
-  createGamePlay,
-} from "./index";
+} from "./types";
+import { type IdolDataId } from "./data/idols";
+import { createIdolInProduction, createGamePlay } from "./models";
+import { createIdGenerator } from "./utils";
 
 export const createGamePlayForTest = (
   options: {
     clearScoreThresholds?: Lesson["clearScoreThresholds"];
     deck?: CardInProduction[];
-    idolDataId?: IdolData["id"];
+    idolDataId?: IdolDataId;
     producerItems?: ProducerItemInProduction[];
     specialTrainingLevel?: number | undefined;
     talentAwakeningLevel?: number | undefined;


### PR DESCRIPTION
- Close: https://github.com/kjirou/gakumas-core/issues/105
- 全面的に置き換えるのは、src/types.ts が全ての型の元になる設計に反するので難しく、部分的に使った
  - データのIDの補完は、結合テストを書いている時が一番欲しいので、とりあえずはそれだけで十分