### PR TITLE
更新クエリ理由を全体的に詳細にする

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -331,7 +331,7 @@ export const startTurn = (gamePlay: GamePlay): GamePlay => {
   const increaseTurnNumberUpdate: LessonUpdateQuery = {
     kind: "turnNumberIncrease",
     reason: {
-      kind: "turnStartTrigger",
+      kind: "turnStart",
       historyTurnNumber: lesson.turnNumber,
       historyResultIndex,
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -278,7 +278,7 @@ export const startTurn = (gamePlay: GamePlay): GamePlay => {
         kind: "turnEnded",
         value: false,
         reason: {
-          kind: "turnEndTrigger",
+          kind: "turnStart",
           historyTurnNumber: lesson.turnNumber,
           historyResultIndex,
         },
@@ -474,7 +474,7 @@ export const startTurn = (gamePlay: GamePlay): GamePlay => {
       kind: "modifierIdsAtTurnStart",
       modifierIdsAtTurnStart: lesson.idol.modifiers.map((e) => e.id),
       reason: {
-        kind: "turnEndTrigger",
+        kind: "turnStart",
         historyTurnNumber: lesson.turnNumber,
         historyResultIndex,
       },
@@ -751,7 +751,7 @@ export const endTurn = (gamePlay: GamePlay): GamePlay => {
           hand: [],
           discardPile: [...lesson.discardPile, ...lesson.hand],
           reason: {
-            kind: "turnEndTrigger",
+            kind: "turnEnd.discardingHand",
             historyTurnNumber: lesson.turnNumber,
             historyResultIndex,
           },
@@ -787,7 +787,7 @@ export const endTurn = (gamePlay: GamePlay): GamePlay => {
       kind: "turnEnded",
       value: true,
       reason: {
-        kind: "turnEndTrigger",
+        kind: "turnEnd",
         historyTurnNumber: lesson.turnNumber,
         historyResultIndex,
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -315,7 +315,7 @@ export const startTurn = (gamePlay: GamePlay): GamePlay => {
       kind: "actionPoints",
       amount: -lesson.idol.actionPoints + 1,
       reason: {
-        kind: "turnSkip",
+        kind: "turnStart",
         historyTurnNumber: lesson.turnNumber,
         historyResultIndex,
       },

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -177,6 +177,22 @@ describe("状態修正の効果時間の自然減少", () => {
     } as LessonDisplay);
   });
 });
+// SSR清夏だけしか持ってなく、E2Eテストに書いてないので、ここで担保する
+describe("レッスン開始時処理", () => {
+  test("概ね正しく動作する", () => {
+    let gamePlay = initializeGamePlay({
+      idolDataId: "shiunsumika-ssr-1",
+      cards: [],
+      producerItems: [],
+      turns: ["vocal"],
+    });
+    gamePlay = startTurn(gamePlay);
+    expect(generateLessonDisplay(gamePlay)).toMatchObject({
+      producerItems: [{ name: "ゲーセンの戦利品", remainingTimes: 0 }],
+      modifiers: [{ name: "集中", representativeValue: 3 }],
+    } as LessonDisplay);
+  });
+});
 describe("「ランダムな強化済みスキルカード（SSR）を、手札に生成」", () => {
   test("概ね正しく動作する", () => {
     for (let i = 0; i < 1000; i++) {

--- a/src/lesson-mutation.ts
+++ b/src/lesson-mutation.ts
@@ -2258,7 +2258,7 @@ export const useCard = (
           params.getRandom,
           params.idGenerator,
           {
-            kind: "cardUsageTrigger",
+            kind: "cardUsage.producerItem.beforeCardEffectActivation",
             cardId: card.id,
             historyTurnNumber: newLesson.turnNumber,
             historyResultIndex: nextHistoryResultIndex,
@@ -2298,7 +2298,7 @@ export const useCard = (
           const innerUpdates = [
             ...diffs.map((diff) =>
               createLessonUpdateQueryFromDiff(diff, {
-                kind: "cardUsageTrigger",
+                kind: "cardUsage.modifier.beforeCardEffectActivation",
                 cardId: card.id,
                 historyTurnNumber: newLesson.turnNumber,
                 historyResultIndex: nextHistoryResultIndex,
@@ -2366,7 +2366,7 @@ export const useCard = (
           params.getRandom,
           params.idGenerator,
           {
-            kind: "cardUsageTrigger",
+            kind: "cardUsage.producerItem.afterCardEffectActivation",
             cardId: card.id,
             historyTurnNumber: newLesson.turnNumber,
             historyResultIndex: nextHistoryResultIndex,
@@ -2391,7 +2391,7 @@ export const useCard = (
           params.getRandom,
           params.idGenerator,
           {
-            kind: "cardUsage.modifierIncreaseEffectActivation",
+            kind: "cardUsage.producerItem.modifierIncreaseEffectActivation",
             cardId: card.id,
             historyTurnNumber: newLesson.turnNumber,
             historyResultIndex: nextHistoryResultIndex,

--- a/src/lesson-mutation.ts
+++ b/src/lesson-mutation.ts
@@ -2493,7 +2493,7 @@ export const activateEffectsOnTurnEnd = (
       );
       const innerUpdates = diffs.map((diff) =>
         createLessonUpdateQueryFromDiff(diff, {
-          kind: "turnEndTrigger",
+          kind: "turnEnd.producerItemEffectActivation",
           historyTurnNumber: lesson.turnNumber,
           historyResultIndex: nextHistoryResultIndex,
         }),
@@ -2526,7 +2526,7 @@ export const activateEffectsOnTurnEnd = (
         if (diffs) {
           innerUpdates = diffs.map((diff) =>
             createLessonUpdateQueryFromDiff(diff, {
-              kind: "turnEndTrigger",
+              kind: "turnEnd.modifierEffectActivation",
               historyTurnNumber: lesson.turnNumber,
               historyResultIndex: nextHistoryResultIndex,
             }),
@@ -2588,7 +2588,7 @@ export const obtainPositiveImpressionScoreOnTurnEnd = (
       ...updates,
       ...diffs.map((diff) =>
         createLessonUpdateQueryFromDiff(diff, {
-          kind: "turnEndTrigger",
+          kind: "turnEnd.scoreIncreaseDueToPositiveImpression",
           historyTurnNumber: lesson.turnNumber,
           historyResultIndex,
         }),

--- a/src/lesson-mutation.ts
+++ b/src/lesson-mutation.ts
@@ -1451,7 +1451,7 @@ export const activateProducerItemEffectsOnTurnStart = (
       );
       const innerUpdates = diff.map((diff) =>
         createLessonUpdateQueryFromDiff(diff, {
-          kind: "turnStartTrigger",
+          kind: "turnStart.producerItem.effectActivation",
           historyTurnNumber: lesson.turnNumber,
           historyResultIndex: nextHistoryResultIndex,
         }),
@@ -1483,7 +1483,7 @@ export const activateProducerItemEffectsOnTurnStart = (
       );
       const innerUpdates = diff.map((diff) =>
         createLessonUpdateQueryFromDiff(diff, {
-          kind: "turnStartTrigger",
+          kind: "turnStart.producerItem.effectActivationEveryTwoTurns",
           historyTurnNumber: lesson.turnNumber,
           historyResultIndex: nextHistoryResultIndex,
         }),
@@ -1541,7 +1541,7 @@ export const activateModifierEffectsOnTurnStart = (
       );
       const innerUpdates = diffs.map((diff) =>
         createLessonUpdateQueryFromDiff(diff, {
-          kind: "turnStartTrigger",
+          kind: "turnStart.modifier.delayedEffectActivation",
           historyTurnNumber: lesson.turnNumber,
           historyResultIndex: nextHistoryResultIndex,
         }),
@@ -1578,7 +1578,7 @@ export const activateModifierEffectsOnTurnStart = (
         );
         const innerUpdates = diffs.map((diff) =>
           createLessonUpdateQueryFromDiff(diff, {
-            kind: "turnStartTrigger",
+            kind: "turnStart.modifier.delayedEffectActivation",
             historyTurnNumber: lesson.turnNumber,
             historyResultIndex: nextHistoryResultIndex,
           }),
@@ -1613,7 +1613,7 @@ export const activateModifierEffectsOnTurnStart = (
         );
         const innerUpdates = diffs.map((diff) =>
           createLessonUpdateQueryFromDiff(diff, {
-            kind: "turnStartTrigger",
+            kind: "turnStart.modifier.delayedEffectActivation",
             historyTurnNumber: lesson.turnNumber,
             historyResultIndex: nextHistoryResultIndex,
           }),
@@ -1686,7 +1686,7 @@ export const drawCardsOnTurnStart = (
           kind: "cardPlacement",
           deck: [...innateCardIds, ...restCardids],
           reason: {
-            kind: "turnStartTrigger",
+            kind: "turnStart",
             historyTurnNumber: newLesson.turnNumber,
             historyResultIndex: nextHistoryResultIndex,
           },
@@ -1719,7 +1719,7 @@ export const drawCardsOnTurnStart = (
           (e) => !handWhenEmptyDeck.includes(e),
         ),
         reason: {
-          kind: "turnStartTrigger",
+          kind: "turnStart",
           historyTurnNumber: newLesson.turnNumber,
           historyResultIndex: nextHistoryResultIndex,
         },
@@ -1749,7 +1749,7 @@ export const drawCardsOnTurnStart = (
           .map((e) => e.id),
       },
       {
-        kind: "turnStartTrigger",
+        kind: "turnStart",
         historyTurnNumber: newLesson.turnNumber,
         historyResultIndex: nextHistoryResultIndex,
       },
@@ -1773,7 +1773,7 @@ export const drawCardsOnTurnStart = (
   );
   drawCardsEffectUpdates = drawCardsEffectDiffs.map((diff) =>
     createLessonUpdateQueryFromDiff(diff, {
-      kind: "turnStartTrigger",
+      kind: "turnStart.drawingHand",
       historyTurnNumber: newLesson.turnNumber,
       historyResultIndex: nextHistoryResultIndex,
     }),
@@ -1803,7 +1803,7 @@ export const drawCardsOnTurnStart = (
         kind: "cardPlacement",
         discardPile: handWhenEmptyDeck,
         reason: {
-          kind: "turnStartTrigger",
+          kind: "turnStart",
           historyTurnNumber: newLesson.turnNumber,
           historyResultIndex: nextHistoryResultIndex,
         },
@@ -1840,8 +1840,8 @@ export const decreaseEachModifierDurationOverTime = (
   let modifierUpdates: LessonUpdateQuery[] = [];
   for (const modifierId of newLesson.idol.modifierIdsAtTurnStart) {
     const modifier = newLesson.idol.modifiers.find((e) => e.id === modifierId);
-    const reason = {
-      kind: "turnStartTrigger",
+    const reason: LessonUpdateQueryReason = {
+      kind: "turnStart.modifier.durationDecreaseOverTime",
       historyTurnNumber: lesson.turnNumber,
       historyResultIndex: nextHistoryResultIndex,
     } as const;
@@ -1925,7 +1925,7 @@ export const activateMemoryEffectsOnLessonStart = (
   let nextHistoryResultIndex = historyResultIndex;
 
   let memoryEffectUpdates: LessonUpdateQuery[] = [];
-  for (const memoryEffect of newLesson.memoryEffects) {
+  for (const [index, memoryEffect] of newLesson.memoryEffects.entries()) {
     const innerUpdates = activateMemoryEffect(
       newLesson,
       memoryEffect,
@@ -1933,7 +1933,8 @@ export const activateMemoryEffectsOnLessonStart = (
       params.idGenerator,
     ).map((diff) =>
       createLessonUpdateQueryFromDiff(diff, {
-        kind: "turnStartTrigger",
+        kind: "turnStart.memoryEffect",
+        index,
         historyTurnNumber: lesson.turnNumber,
         historyResultIndex: nextHistoryResultIndex,
       }),

--- a/src/lesson-mutation.ts
+++ b/src/lesson-mutation.ts
@@ -1350,7 +1350,9 @@ export const activateEffectsOnLessonStart = (
       );
       const innerUpdates = diffs.map((diff) =>
         createLessonUpdateQueryFromDiff(diff, {
-          kind: "lessonStartTrigger",
+          kind: "lessonStart.producerItemEffectActivation",
+          producerItemId: producerItem.id,
+          producerItemDataId: producerItem.original.data.id,
           historyTurnNumber: lesson.turnNumber,
           historyResultIndex: nextHistoryResultIndex,
         }),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1570,8 +1570,10 @@ export type LessonUpdateQueryReason = Readonly<
         kind: "lessonInitialization";
       }
     | {
-        /** レッスン開始時トリガーにより発動した効果 */
-        kind: "lessonStartTrigger";
+        /** レッスン開始.Pアイテム効果発動 */
+        kind: "lessonStart.producerItemEffectActivation";
+        producerItemId: ProducerItem["id"];
+        producerItemDataId: ProducerItemData["id"];
       }
     | {
         /** 状態修正増加トリガーにより発動した効果 */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1612,18 +1612,40 @@ export type LessonUpdateQueryReason = Readonly<
         kind: "turnSkip";
       }
     | {
-        /** 非推奨、ターン開始時トリガーにより発動した効果 */
-        kind: "turnStartTrigger";
-      }
-    | {
         /** ターン開始 */
         kind: "turnStart";
+      }
+    | {
+        /** ターン開始.手札を引く */
+        kind: "turnStart.drawingHand";
       }
     | {
         /** ターン開始.応援/トラブル */
         kind: "turnStart.encouragement";
         /** lesson.encouragements のインデックス */
         index: number;
+      }
+    | {
+        /** ターン開始.メモリーのアビリティ */
+        kind: "turnStart.memoryEffect";
+        /** lesson.memoryEffects のインデックス */
+        index: number;
+      }
+    | {
+        /** ターン開始.状態修正.遅延効果発動 */
+        kind: "turnStart.modifier.delayedEffectActivation";
+      }
+    | {
+        /** ターン開始.状態修正.ターン経過による効果時間減少 */
+        kind: "turnStart.modifier.durationDecreaseOverTime";
+      }
+    | {
+        /** ターン開始.Pアイテム.効果発動 */
+        kind: "turnStart.producerItem.effectActivation";
+      }
+    | {
+        /** ターン開始.Pアイテム.2ターン毎の効果発動 */
+        kind: "turnStart.producerItem.effectActivationEveryTwoTurns";
       }
     | {
         /** テストのダミー値としてや開発時に一時的に設定 */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1578,18 +1578,10 @@ export type LessonUpdateQueryReason = Readonly<
         kind: "drinkUsage.effectActivation";
       }
     | {
-        /** レッスン終了 */
-        kind: "lessonEnd";
-      }
-    | {
         /** レッスン開始.Pアイテム効果発動 */
         kind: "lessonStart.producerItemEffectActivation";
         producerItemId: ProducerItem["id"];
         producerItemDataId: ProducerItemData["id"];
-      }
-    | {
-        /** 状態修正増加トリガーにより発動した効果 */
-        kind: "modifierIncreaseTrigger";
       }
     | {
         /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1540,18 +1540,28 @@ export type LessonUpdateQueryReason = Readonly<
         effectIndex: number;
       }
     | {
-        /** スキルカード使用.状態修正増加起因の効果発動 */
-        kind: "cardUsage.modifierIncreaseEffectActivation";
+        /** スキルカード使用.状態修正.主効果発動前の効果発動, TODO: 状態修正情報を含める */
+        kind: "cardUsage.modifier.beforeCardEffectActivation";
+        cardId: Card["id"];
+      }
+    | {
+        /** スキルカード使用.Pアイテム.主効果発動後の効果発動, TODO: Pアイテム情報を含める */
+        kind: "cardUsage.producerItem.afterCardEffectActivation";
+        cardId: Card["id"];
+      }
+    | {
+        /** スキルカード使用.Pアイテム.主効果発動前の効果発動, TODO: Pアイテム情報を含める */
+        kind: "cardUsage.producerItem.beforeCardEffectActivation";
+        cardId: Card["id"];
+      }
+    | {
+        /** スキルカード使用.Pアイテム.状態修正増加起因の効果発動, TODO: Pアイテム情報と状態修正情報を含める */
+        kind: "cardUsage.producerItem.modifierIncreaseEffectActivation";
         cardId: Card["id"];
       }
     | {
         /** スキルカード使用.残りスキルカード使用数消費 */
         kind: "cardUsage.remainingCardUsageCountConsumption";
-      }
-    | {
-        /** スキルカード使用時トリガーにより発動した効果 */
-        kind: "cardUsageTrigger";
-        cardId: Card["id"];
       }
     | {
         /** Pドリンク使用.消費 */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1566,10 +1566,6 @@ export type LessonUpdateQueryReason = Readonly<
         kind: "lessonEnd";
       }
     | {
-        /** レッスン生成直後 */
-        kind: "lessonInitialization";
-      }
-    | {
         /** レッスン開始.Pアイテム効果発動 */
         kind: "lessonStart.producerItemEffectActivation";
         producerItemId: ProducerItem["id"];

--- a/src/types.ts
+++ b/src/types.ts
@@ -1519,13 +1519,19 @@ type LessonHistoryRecord =
 export type LessonUpdateQueryReason = Readonly<
   (
     | {
-        /** 非推奨、スキルカード使用 */
+        /** スキルカード使用 */
         kind: "cardUsage";
         cardId: Card["id"];
       }
     | {
-        /** スキルカード使用.残りスキルカード使用数消費 */
-        kind: "cardUsage.remainingCardUsageCountConsumption";
+        /** スキルカード使用.手札消費 */
+        kind: "cardUsage.cardConsumption";
+        cardId: Card["id"];
+      }
+    | {
+        /** スキルカード使用.コスト消費 */
+        kind: "cardUsage.costConsumption";
+        cardId: Card["id"];
       }
     | {
         /** スキルカード使用.主効果発動 */
@@ -1537,6 +1543,10 @@ export type LessonUpdateQueryReason = Readonly<
         /** スキルカード使用.状態修正増加起因の効果発動 */
         kind: "cardUsage.modifierIncreaseEffectActivation";
         cardId: Card["id"];
+      }
+    | {
+        /** スキルカード使用.残りスキルカード使用数消費 */
+        kind: "cardUsage.remainingCardUsageCountConsumption";
       }
     | {
         /** スキルカード使用プレビュー */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1540,22 +1540,22 @@ export type LessonUpdateQueryReason = Readonly<
         effectIndex: number;
       }
     | {
-        /** スキルカード使用.状態修正.主効果発動前の効果発動, TODO: 状態修正情報を含める */
+        /** スキルカード使用.状態修正.主効果発動前の効果発動 */
         kind: "cardUsage.modifier.beforeCardEffectActivation";
         cardId: Card["id"];
       }
     | {
-        /** スキルカード使用.Pアイテム.主効果発動後の効果発動, TODO: Pアイテム情報を含める */
+        /** スキルカード使用.Pアイテム.主効果発動後の効果発動 */
         kind: "cardUsage.producerItem.afterCardEffectActivation";
         cardId: Card["id"];
       }
     | {
-        /** スキルカード使用.Pアイテム.主効果発動前の効果発動, TODO: Pアイテム情報を含める */
+        /** スキルカード使用.Pアイテム.主効果発動前の効果発動 */
         kind: "cardUsage.producerItem.beforeCardEffectActivation";
         cardId: Card["id"];
       }
     | {
-        /** スキルカード使用.Pアイテム.状態修正増加起因の効果発動, TODO: Pアイテム情報と状態修正情報を含める */
+        /** スキルカード使用.Pアイテム.状態修正増加起因の効果発動 */
         kind: "cardUsage.producerItem.modifierIncreaseEffectActivation";
         cardId: Card["id"];
       }
@@ -1584,12 +1584,28 @@ export type LessonUpdateQueryReason = Readonly<
         producerItemDataId: ProducerItemData["id"];
       }
     | {
-        /**
-         * ターン終了時トリガーにより発動した効果
-         *
-         * - 好調や好印象などのターン経過毎の減少もこれで表現する
-         */
-        kind: "turnEndTrigger";
+        /** ターン終了 */
+        kind: "turnEnd";
+      }
+    | {
+        /** ターン終了.手札を捨てる */
+        kind: "turnEnd.discardingHand";
+      }
+    | {
+        /** ターン終了.状態修正の効果発動 */
+        kind: "turnEnd.modifierEffectActivation";
+      }
+    | {
+        /** ターン終了.Pアイテムの効果発動 */
+        kind: "turnEnd.producerItemEffectActivation";
+      }
+    | {
+        /** ターン終了.好印象によるパラメータ/スコア増加 */
+        kind: "turnEnd.scoreIncreaseDueToPositiveImpression";
+      }
+    | {
+        /** ターン終了.好印象によるパラメータ/スコア増加 */
+        kind: "turnEnd.scoreIncreaseDueToPositiveImpression";
       }
     | {
         /** ターンのスキップ */
@@ -1600,7 +1616,11 @@ export type LessonUpdateQueryReason = Readonly<
         kind: "turnStartTrigger";
       }
     | {
-        /** ターン開始時処理.応援/トラブル */
+        /** ターン開始 */
+        kind: "turnStart";
+      }
+    | {
+        /** ターン開始.応援/トラブル */
         kind: "turnStart.encouragement";
         /** lesson.encouragements のインデックス */
         index: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1549,10 +1549,6 @@ export type LessonUpdateQueryReason = Readonly<
         kind: "cardUsage.remainingCardUsageCountConsumption";
       }
     | {
-        /** スキルカード使用プレビュー */
-        kind: "cardUsagePreview";
-      }
-    | {
         /** スキルカード使用時トリガーにより発動した効果 */
         kind: "cardUsageTrigger";
         cardId: Card["id"];


### PR DESCRIPTION
- Close: https://github.com/kjirou/gakumas-core/issues/120
- 方針
  - 大きくは、a)UIのアニメーション・インタラクション用と b)デバッグ用の2つの用途があるが、前者側を詳細にする
    - b は必要になったらでいい、また a をある程度入れればそれだけでも十分かもしれない
    - 内部処理のための更新クエリは、汎用種別のままで良い
  - 処理を変えないといけないところは後回し
    - UIで使ってみないと意味の半分は実感できないし、今はまずUIに置いてみるのが一番優先度高い