### PR TITLE
現在のターン詳細情報を表示情報へ含める

### DIFF
--- a/src/display.ts
+++ b/src/display.ts
@@ -35,6 +35,7 @@ import {
   calculateModifierEffectedActionCost,
   calculateRemainingTurns,
   createActualTurns,
+  createCurrentTurnDetails,
   getCardContentData,
   getDisplayedRepresentativeModifierValue,
   getIdolParameterKindOnTurn,
@@ -358,6 +359,7 @@ export const generateLessonDisplay = (gamePlay: GamePlay): LessonDisplay => {
   });
   return {
     clearScoreThresholds: lesson.clearScoreThresholds,
+    currentTurn: createCurrentTurnDetails(lesson),
     drinks: generateDrinkDisplays(lesson),
     hand,
     inventory: {
@@ -379,11 +381,8 @@ export const generateLessonDisplay = (gamePlay: GamePlay): LessonDisplay => {
     ),
     modifiers,
     producerItems: generateProducerItemDisplays(lesson),
-    remainingTurns: calculateRemainingTurns(lesson),
-    remainingTurnsChange: lesson.remainingTurnsChange,
     score: lesson.score,
     scoreBonus,
-    turnNumber: lesson.turnNumber,
     turns,
     vitality: lesson.idol.vitality,
   };

--- a/src/display.ts
+++ b/src/display.ts
@@ -33,7 +33,6 @@ import {
 } from "./lesson-mutation";
 import {
   calculateModifierEffectedActionCost,
-  calculateRemainingTurns,
   createActualTurns,
   createCurrentTurnDetails,
   getCardContentData,

--- a/src/e2e-tests/fujitakotone-ssr-1.test.ts
+++ b/src/e2e-tests/fujitakotone-ssr-1.test.ts
@@ -517,8 +517,11 @@ test("最終試験その1を再現する", () => {
       { name: "やる気", representativeValue: 12 },
     ],
     score: 2459,
-    remainingTurns: 7,
-    remainingTurnsChange: 0,
+    currentTurn: {
+      remainingTurns: 7,
+      additionalTurns: 0,
+      remainingAdditionalTurns: 0,
+    },
   } as LessonDisplay);
   gamePlay = playCard(gamePlay, 1);
   gamePlay = playCard(gamePlay, 2);
@@ -534,8 +537,11 @@ test("最終試験その1を再現する", () => {
       { name: "やる気", representativeValue: 15 },
     ],
     score: 3057,
-    remainingTurns: 7,
-    remainingTurnsChange: 1,
+    currentTurn: {
+      remainingTurns: 7,
+      additionalTurns: 1,
+      remainingAdditionalTurns: 1,
+    },
   } as LessonDisplay);
   gamePlay = playCard(gamePlay, 0);
   gamePlay = playCard(gamePlay, 0);

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ import {
   useDrink as useDrinkMutation,
 } from "./lesson-mutation";
 import {
-  calculateRemainingTurns,
+  createCurrentTurnDetails,
   createIdolInProduction,
   createGamePlay,
   getNextHistoryResultIndex,
@@ -227,7 +227,7 @@ export const isLessonEnded = (gamePlay: GamePlay): boolean => {
   const lesson = getLesson(gamePlay);
   return (
     isScoreSatisfyingPerfect(lesson) ||
-    (calculateRemainingTurns(lesson) === 1 &&
+    (createCurrentTurnDetails(lesson).remainingTurns === 1 &&
       hasActionEnded(gamePlay) &&
       lesson.turnEnded)
   );

--- a/src/lesson-mutation.ts
+++ b/src/lesson-mutation.ts
@@ -27,7 +27,7 @@ import { metaModifierDictioanry } from "./data/modifiers";
 import {
   calculateModifierEffectedActionCost,
   calculateClearScoreProgress,
-  calculateRemainingTurns,
+  createCurrentTurnDetails,
   getCardContentData,
   getIdolParameterKindOnTurn,
   getProducerItemContentData,
@@ -347,7 +347,7 @@ export const canActivateEffect = (
       return validateNumberInRange(targetValue, condition.range);
     }
     case "countReminingTurns": {
-      return calculateRemainingTurns(lesson) <= condition.max;
+      return createCurrentTurnDetails(lesson).remainingTurns <= condition.max;
     }
     case "countVitality": {
       return validateNumberInRange(lesson.idol.vitality, condition.range);

--- a/src/models.ts
+++ b/src/models.ts
@@ -41,6 +41,7 @@ import {
   ProducerItemContentData,
   ProducerItemInProduction,
   CharacterData,
+  CurrentTurnDetails,
 } from "./types";
 import { shuffleArray } from "./utils";
 
@@ -380,9 +381,28 @@ export const getIdolParameterKindOnTurn = (
   return lesson.turnNumber === 0 ? turns[0] : turns[lesson.turnNumber - 1];
 };
 
-/** 残りターン数を計算する、最終ターンは1 */
 export const calculateRemainingTurns = (lesson: Lesson): number =>
   createActualTurns(lesson).length - lesson.turnNumber + 1;
+
+export const createCurrentTurnDetails = (
+  lesson: Lesson,
+): CurrentTurnDetails => {
+  const pastTurns = lesson.turnNumber - 1;
+  const originalTurns = lesson.turns.length;
+  const remainingOriginalTurns = Math.max(originalTurns - pastTurns, 0);
+  const additionalTurns = lesson.remainingTurnsChange;
+  const remainingAdditionalTurns =
+    additionalTurns - Math.max(pastTurns - originalTurns, 0);
+  return {
+    additionalTurns,
+    idolParameterKind: getIdolParameterKindOnTurn(lesson),
+    originalTurns,
+    remainingTurns: remainingOriginalTurns + remainingAdditionalTurns,
+    remainingAdditionalTurns,
+    remainingOriginalTurns,
+    turnNumber: lesson.turnNumber,
+  };
+};
 
 /**
  * 状態修正による補正を適用したコストへ変換して返す

--- a/src/models.ts
+++ b/src/models.ts
@@ -381,9 +381,6 @@ export const getIdolParameterKindOnTurn = (
   return lesson.turnNumber === 0 ? turns[0] : turns[lesson.turnNumber - 1];
 };
 
-export const calculateRemainingTurns = (lesson: Lesson): number =>
-  createActualTurns(lesson).length - lesson.turnNumber + 1;
-
 export const createCurrentTurnDetails = (
   lesson: Lesson,
 ): CurrentTurnDetails => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1338,6 +1338,26 @@ export type Lesson = {
 };
 
 /**
+ * 現在のターンの詳細情報
+ *
+ * - 各種残りターン数は、最後のターンの時は 1 になる
+ */
+export type CurrentTurnDetails = {
+  /** ターン追加効果により増加したターン数 */
+  additionalTurns: number;
+  idolParameterKind: IdolParameterKind;
+  /** レッスン定義上のターン数 */
+  originalTurns: number;
+  /** 残りターン数の総数、本家UIにこの表示はない */
+  remainingTurns: number;
+  /** 残りターン数の内、ターン追加効果由来の分 */
+  remainingAdditionalTurns: number;
+  /** 残りターン数の内、レッスン定義由来の分 */
+  remainingOriginalTurns: number;
+  turnNumber: Lesson["turnNumber"];
+};
+
+/**
  * レッスン更新差分
  *
  * - レッスンの状態の変化を表現したもの
@@ -1871,6 +1891,7 @@ export type TurnDisplay = {
  */
 export type LessonDisplay = {
   clearScoreThresholds: Lesson["clearScoreThresholds"];
+  currentTurn: CurrentTurnDetails;
   drinks: DrinkDisplay[];
   hand: CardInHandDisplay[];
   inventory: {
@@ -1884,11 +1905,8 @@ export type LessonDisplay = {
   lifeRecoveredBySkippingTurn: number;
   modifiers: ModifierDisplay[];
   producerItems: ProducerItemDisplay[];
-  remainingTurns: number;
-  remainingTurnsChange: Lesson["remainingTurnsChange"];
   score: Lesson["score"];
   scoreBonus: number | undefined;
-  turnNumber: number;
   /** ターン追加を反映した長さのターンリスト */
   turns: TurnDisplay[];
   vitality: Idol["vitality"];


### PR DESCRIPTION
- 本家UIが、割と複雑な出し方をしていた
  - 「ターン追加分を除く分（つまり、本来のレッスン定義上のターン数）の残りターン数」が0になると、「ターン追加分の残りターン数」の表示に切り替える