### PR TITLE
IdolInProductionの概念を削除

### DIFF
--- a/src/display.test.ts
+++ b/src/display.test.ts
@@ -32,7 +32,7 @@ describe("generateCardInHandDisplay", () => {
       name: "基本的なスキルカードを要約できる",
       args: [
         createLessonForTest({
-          deck: [
+          cards: [
             {
               id: "a",
               data: getCardDataByConstId("apirunokihon"),
@@ -60,7 +60,7 @@ describe("generateCardInHandDisplay", () => {
       args: [
         (() => {
           const lesson = createLessonForTest({
-            deck: [
+            cards: [
               {
                 id: "a",
                 data: getCardDataByConstId("apirunokihon"),
@@ -93,7 +93,7 @@ describe("generateCardInHandDisplay", () => {
       args: [
         (() => {
           const lesson = createLessonForTest({
-            deck: [
+            cards: [
               {
                 id: "a",
                 data: getCardDataByConstId("apirunokihon"),
@@ -124,7 +124,7 @@ describe("generateCardInHandDisplay", () => {
       args: [
         (() => {
           const lesson = createLessonForTest({
-            deck: [
+            cards: [
               {
                 id: "a",
                 data: getCardDataByConstId("pozunokihon"),
@@ -147,7 +147,7 @@ describe("generateCardInHandDisplay", () => {
       name: "無条件の状態修正と条件付きの状態修正を持つスキルカードで、後者の条件を満たさない時、effectsには条件を満たした旨と満たさない旨の2レコードが入る",
       args: [
         createLessonForTest({
-          deck: [
+          cards: [
             {
               id: "a",
               data: getCardDataByConstId("rakkanteki"),
@@ -185,7 +185,7 @@ describe("generateCardInHandDisplay", () => {
       name: "無条件のスコアと条件付きのスコアを持つスキルカードで、後者の条件を満たさない時、effectsには条件を満たさない旨の内容が入り、scoresには無条件のスコアのみ入る",
       args: [
         createLessonForTest({
-          deck: [
+          cards: [
             {
               id: "a",
               data: getCardDataByConstId("hiyaku"),
@@ -219,7 +219,7 @@ describe("generateCardInHandDisplay", () => {
       args: [
         (() => {
           const lesson = createLessonForTest({
-            deck: [
+            cards: [
               {
                 id: "a",
                 data: getCardDataByConstId("hiyaku"),
@@ -258,7 +258,7 @@ describe("generateCardInHandDisplay", () => {
       name: "無条件の元気と条件付きの元気を持つスキルカードで、後者の条件を満たさない時、effectsには条件を満たさない旨の内容が入り、vitalityには無条件の値のみ入る",
       args: [
         createLessonForTest({
-          deck: [
+          cards: [
             {
               id: "a",
               data: getCardDataByConstId("honkinoshumi"),
@@ -292,7 +292,7 @@ describe("generateCardInHandDisplay", () => {
       args: [
         (() => {
           const lesson = createLessonForTest({
-            deck: [
+            cards: [
               {
                 id: "a",
                 data: getCardDataByConstId("honkinoshumi"),
@@ -329,7 +329,7 @@ describe("generateCardInHandDisplay", () => {
       args: [
         (() => {
           const lesson = createLessonForTest({
-            deck: [
+            cards: [
               {
                 id: "a",
                 data: getCardDataByConstId("apirunokihon"),
@@ -365,7 +365,7 @@ describe("generateCardInHandDisplay", () => {
       name: "スキルカード使用条件を満たさない時も、スコアの算出を行う",
       args: [
         createLessonForTest({
-          deck: [
+          cards: [
             {
               id: "a",
               data: getCardDataByConstId("chosen"),
@@ -393,7 +393,7 @@ describe("generateCardInHandDisplay", () => {
       args: [
         (() => {
           const lesson = createLessonForTest({
-            deck: [
+            cards: [
               {
                 id: "a",
                 data: getCardDataByConstId("wammoasuteppu"),
@@ -576,7 +576,7 @@ describe("generateCardPlayPreviewDisplay", () => {
       args: [
         (() => {
           const gamePlay = createGamePlayForTest({
-            deck: [
+            cards: [
               {
                 id: "c1",
                 data: getCardDataByConstId("jonetsutan"),
@@ -665,7 +665,7 @@ describe("generateCardPlayPreviewDisplay", () => {
       args: [
         (() => {
           const gamePlay = createGamePlayForTest({
-            deck: [
+            cards: [
               {
                 id: "c1",
                 data: getCardDataByConstId("apirunokihon"),
@@ -688,7 +688,7 @@ describe("generateCardPlayPreviewDisplay", () => {
       args: [
         (() => {
           const gamePlay = createGamePlayForTest({
-            deck: [
+            cards: [
               {
                 id: "c1",
                 data: getCardDataByConstId("hidamarinoseitokaishitsu"),
@@ -711,7 +711,7 @@ describe("generateCardPlayPreviewDisplay", () => {
       args: [
         (() => {
           const gamePlay = createGamePlayForTest({
-            deck: [
+            cards: [
               {
                 id: "c1",
                 data: getCardDataByConstId("shupurehikoru"),
@@ -756,7 +756,7 @@ describe("generateCardPlayPreviewDisplay", () => {
       args: [
         (() => {
           const gamePlay = createGamePlayForTest({
-            deck: [
+            cards: [
               {
                 id: "c1",
                 data: getCardDataByConstId("aidorusengen"),
@@ -781,7 +781,7 @@ describe("generateCardPlayPreviewDisplay", () => {
       args: [
         (() => {
           const gamePlay = createGamePlayForTest({
-            deck: [
+            cards: [
               {
                 id: "c1",
                 data: getCardDataByConstId("aidorusengen"),
@@ -893,7 +893,7 @@ describe("generateLessonDisplay", () => {
       args: [
         (() => {
           const gamePlay = createGamePlayForTest({
-            deck: [
+            cards: [
               {
                 id: "c1",
                 data: getCardDataByConstId("apirunokihon"),
@@ -941,7 +941,7 @@ describe("generateLessonDisplay", () => {
       args: [
         (() => {
           const gamePlay = createGamePlayForTest({
-            deck: [
+            cards: [
               {
                 id: "c1",
                 data: getCardDataByConstId("apirunokihon"),

--- a/src/display.test.ts
+++ b/src/display.test.ts
@@ -986,7 +986,7 @@ describe("generateLessonDisplay", () => {
         (() => {
           const gamePlay = createGamePlayForTest();
           gamePlay.initialLesson.idol.life =
-            gamePlay.initialLesson.idol.original.maxLife - 3;
+            gamePlay.initialLesson.idol.maxLife - 3;
           return gamePlay;
         })(),
       ],

--- a/src/display.ts
+++ b/src/display.ts
@@ -320,7 +320,7 @@ export const generateLessonDisplay = (gamePlay: GamePlay): LessonDisplay => {
   const modifiers = generateModifierDisplays({
     modifiers: lesson.idol.modifiers,
     recommendedModifierKind:
-      lesson.idol.original.data.producePlan.recommendedModifierKind,
+      lesson.idol.data.producePlan.recommendedModifierKind,
   });
   const encouragements = generateEncouragementDisplays(
     gamePlay.initialLesson.encouragements,
@@ -376,7 +376,7 @@ export const generateLessonDisplay = (gamePlay: GamePlay): LessonDisplay => {
     life: lesson.idol.life,
     lifeRecoveredBySkippingTurn: Math.min(
       lifeRecoveredBySkippingTurn,
-      lesson.idol.original.maxLife - lesson.idol.life,
+      lesson.idol.maxLife - lesson.idol.life,
     ),
     modifiers,
     producerItems: generateProducerItemDisplays(lesson),
@@ -439,7 +439,7 @@ export const generateCardPlayPreviewDisplay = (
         beforeModifiers: beforeLesson.idol.modifiers,
         modifiers: afterLesson.idol.modifiers,
         recommendedModifierKind:
-          beforeLesson.idol.original.data.producePlan.recommendedModifierKind,
+          beforeLesson.idol.data.producePlan.recommendedModifierKind,
       }),
       score: {
         after: afterLesson.score,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -59,9 +59,7 @@ describe("initializeGamePlay", () => {
       expected: {
         initialLesson: {
           idol: {
-            original: {
-              data: getIdolDataByConstId("kuramotochina-ssr-1"),
-            },
+            data: getIdolDataByConstId("kuramotochina-ssr-1"),
             producerItems: [
               {
                 original: {
@@ -150,9 +148,7 @@ describe("initializeGamePlay", () => {
       expected: {
         initialLesson: {
           idol: {
-            original: {
-              maxLife: 28,
-            },
+            maxLife: 28,
           },
         },
       } as GamePlay,
@@ -171,9 +167,7 @@ describe("initializeGamePlay", () => {
       expected: {
         initialLesson: {
           idol: {
-            original: {
-              maxLife: 100,
-            },
+            maxLife: 100,
           },
         },
       } as GamePlay,

--- a/src/index.ts
+++ b/src/index.ts
@@ -673,7 +673,7 @@ export const skipTurn = (gamePlay: GamePlay): GamePlay => {
       actual:
         Math.min(
           lifeRecoveredBySkippingTurn,
-          lesson.idol.original.maxLife - lesson.idol.life,
+          lesson.idol.maxLife - lesson.idol.life,
         ) + 0,
       max: lifeRecoveredBySkippingTurn,
       reason: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,6 @@ import {
 } from "./lesson-mutation";
 import {
   createCurrentTurnDetails,
-  createIdolInProduction,
   createGamePlay,
   getNextHistoryResultIndex,
   isScoreSatisfyingPerfect,
@@ -176,26 +175,22 @@ export const initializeGamePlay = (params: {
       data: getDrinkDataById(drinkSetting.id),
     };
   });
-  const idolInProduction = createIdolInProduction({
+  return createGamePlay({
     additionalCards,
     additionalProducerItems,
-    idGenerator,
-    idolDataId: params.idolDataId,
-    life: params.life,
-    maxLife: params.maxLife,
-    specialTrainingLevel,
-    specificCardId: params.idolSpecificCardTestId,
-    talentAwakeningLevel,
-  });
-  return createGamePlay({
     clearScoreThresholds: params.clearScoreThresholds,
     drinks,
     encouragements: params.encouragements,
     idGenerator,
-    idolInProduction,
+    idolDataId: params.idolDataId,
+    idolSpecificCardTestId: params.idolSpecificCardTestId,
     ignoreIdolParameterKindConditionAfterClearing,
+    life: params.life,
+    maxLife: params.maxLife,
     memoryEffects: params.memoryEffects,
     scoreBonus: params.scoreBonus,
+    specialTrainingLevel,
+    talentAwakeningLevel,
     turns: params.turns,
   });
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,6 @@ import {
   MemoryEffect,
   CardInProduction,
   ProducerItemInProduction,
-  IdolInProduction,
   Drink,
   NextLifecyclePhase,
 } from "./types";
@@ -135,8 +134,8 @@ export const initializeGamePlay = (params: {
   idolDataId: IdolDataId;
   idolSpecificCardTestId?: CardInProduction["id"];
   ignoreIdolParameterKindConditionAfterClearing?: Lesson["ignoreIdolParameterKindConditionAfterClearing"];
-  life?: IdolInProduction["life"];
-  maxLife?: IdolInProduction["maxLife"];
+  life?: Idol["life"];
+  maxLife?: Idol["maxLife"];
   memoryEffects?: MemoryEffect[];
   producerItems: Array<{
     enhanced?: ProducerItemInProduction["enhanced"];

--- a/src/lesson-mutation.test.ts
+++ b/src/lesson-mutation.test.ts
@@ -313,7 +313,7 @@ describe("activateEffectIf", () => {
       args: [
         (() => {
           const lesson = createLessonForTest();
-          lesson.idol.life = lesson.idol.original.maxLife - 1;
+          lesson.idol.life = lesson.idol.maxLife - 1;
           return lesson;
         })(),
         { kind: "recoverLife", value: 2 },
@@ -2361,9 +2361,7 @@ describe("canActivateEffect", () => {
         {
           idol: {
             life: 5,
-            original: {
-              maxLife: 10,
-            },
+            maxLife: 10,
           },
         } as Lesson,
         { kind: "measureIfLifeIsEqualGreaterThanHalf" },
@@ -2376,9 +2374,7 @@ describe("canActivateEffect", () => {
         {
           idol: {
             life: 4,
-            original: {
-              maxLife: 10,
-            },
+            maxLife: 10,
           },
         } as Lesson,
         { kind: "measureIfLifeIsEqualGreaterThanHalf" },
@@ -2531,9 +2527,7 @@ describe("canPlayCard", () => {
         {
           idol: {
             life: 5,
-            original: {
-              maxLife: 10,
-            },
+            maxLife: 10,
             vitality: 0,
             modifiers: [] as Idol["modifiers"],
           },
@@ -2554,9 +2548,7 @@ describe("canPlayCard", () => {
         {
           idol: {
             life: 4,
-            original: {
-              maxLife: 10,
-            },
+            maxLife: 10,
             vitality: 0,
             modifiers: [] as Idol["modifiers"],
           },
@@ -2577,9 +2569,7 @@ describe("canPlayCard", () => {
         {
           idol: {
             life: 5,
-            original: {
-              maxLife: 10,
-            },
+            maxLife: 10,
             vitality: 0,
             modifiers: [] as Idol["modifiers"],
           },
@@ -2600,9 +2590,7 @@ describe("canPlayCard", () => {
         {
           idol: {
             life: 6,
-            original: {
-              maxLife: 10,
-            },
+            maxLife: 10,
             vitality: 0,
             modifiers: [] as Idol["modifiers"],
           },

--- a/src/lesson-mutation.test.ts
+++ b/src/lesson-mutation.test.ts
@@ -78,7 +78,7 @@ describe("activateEffectIf", () => {
       name: "generateCard - 手札0枚で実行した時、強化されたSSRのスキルカードを追加して、手札はその1枚になる",
       args: [
         (() => {
-          const lesson = createLessonForTest({ deck: [] });
+          const lesson = createLessonForTest({ cards: [] });
           return lesson;
         })(),
         { kind: "generateCard" },
@@ -110,7 +110,7 @@ describe("activateEffectIf", () => {
       name: "generateTroubleCard - 山札0枚で実行した時、眠気スキルカードを追加して、山札はその1枚になる",
       args: [
         (() => {
-          const lesson = createLessonForTest({ deck: [] });
+          const lesson = createLessonForTest({ cards: [] });
           return lesson;
         })(),
         { kind: "generateTroubleCard" },
@@ -1242,7 +1242,7 @@ describe("activateMemoryEffectsOnLessonStart", () => {
 describe("activateModifierEffectsOnTurnStart", () => {
   test("次ターンと2ターン後にパラメータ追加する状態修正がある時、1回パラメータを追加し、それらの状態修正の残りターン数を減少する", () => {
     const lesson = createLessonForTest({
-      deck: [
+      cards: [
         {
           id: "a",
           data: getCardDataByConstId("apirunokihon"),
@@ -1307,7 +1307,7 @@ describe("activateModifierEffectsOnTurnStart", () => {
   });
   test("次ターンにスキルカードを1枚引く状態修正がある時、手札が1枚増え、その状態修正を減少する", () => {
     const lesson = createLessonForTest({
-      deck: [
+      cards: [
         {
           id: "a",
           data: getCardDataByConstId("apirunokihon"),
@@ -1352,7 +1352,7 @@ describe("activateModifierEffectsOnTurnStart", () => {
   });
   test("次ターン・2ターン後・次ターンにスキルカードを1枚引く状態修正がある時、手札1枚増加を2回行い、全ての状態修正を減少する", () => {
     const lesson = createLessonForTest({
-      deck: [
+      cards: [
         ...["a", "b"].map((id) => ({
           id,
           data: getCardDataByConstId("apirunokihon"),
@@ -1437,7 +1437,7 @@ describe("activateModifierEffectsOnTurnStart", () => {
   });
   test("次ターンに手札を強化するを状態修正がある時、手札が全て強化され、その状態修正を減少する", () => {
     const lesson = createLessonForTest({
-      deck: [
+      cards: [
         ...["a", "b"].map((id) => ({
           id,
           data: getCardDataByConstId("apirunokihon"),
@@ -1482,7 +1482,7 @@ describe("activateModifierEffectsOnTurnStart", () => {
   });
   test("次ターンにスキルカードを引く状態修正と手札を強化する状態修正がある時、手札が引かれた状態で、手札が全て強化される", () => {
     const lesson = createLessonForTest({
-      deck: [
+      cards: [
         ...["a", "b"].map((id) => ({
           id,
           data: getCardDataByConstId("apirunokihon"),
@@ -3368,7 +3368,7 @@ describe("drawCardsFromDeck", () => {
 describe("drawCardsOnTurnStart", () => {
   test("山札に引く数が残っている時、山札はその分減り、捨札に変化はない / 1ターン目でレッスン開始時手札がない時、その更新は発行されない", () => {
     const lesson = createLessonForTest({
-      deck: [
+      cards: [
         ...["a", "b", "c", "d"].map((id) => ({
           id,
           data: getCardDataByConstId("apirunokihon"),
@@ -3393,7 +3393,7 @@ describe("drawCardsOnTurnStart", () => {
   });
   test("山札に引く数が残っていない時、山札は再構築された上で残りの引く数分減り、捨札は空になる", () => {
     const lesson = createLessonForTest({
-      deck: [
+      cards: [
         ...["a", "b", "c", "d"].map((id) => ({
           id,
           data: getCardDataByConstId("apirunokihon"),
@@ -3415,7 +3415,7 @@ describe("drawCardsOnTurnStart", () => {
   });
   test("山札が0枚で、前ターンに1枚捨札へ移動した時、山札は再構築され、捨札はその1枚のみになり、前ターンに1枚捨札へ移動したフラグは消える", () => {
     const lesson = createLessonForTest({
-      deck: [
+      cards: [
         ...["a", "b", "c", "d", "e"].map((id) => ({
           id,
           data: getCardDataByConstId("apirunokihon"),
@@ -3448,7 +3448,7 @@ describe("drawCardsOnTurnStart", () => {
   });
   test("山札も捨札も0枚の時、手札0枚になる", () => {
     const lesson = createLessonForTest({
-      deck: [],
+      cards: [],
     });
     lesson.hand = [];
     lesson.deck = [];
@@ -3461,7 +3461,7 @@ describe("drawCardsOnTurnStart", () => {
   });
   test("1ターン目でレッスン開始時手札が1枚ある時、更新は2回発行され、手札は最終的にその札を含む3枚になる", () => {
     const lesson = createLessonForTest({
-      deck: [
+      cards: [
         ...["a", "b", "c"].map((id) => ({
           id,
           data: getCardDataByConstId("apirunokihon"),
@@ -3495,7 +3495,7 @@ describe("drawCardsOnTurnStart", () => {
   });
   test("1ターン目でレッスン開始時手札が5枚ある時、手札は最終的にレッスン開始時手札のみの5枚になる", () => {
     const lesson = createLessonForTest({
-      deck: [
+      cards: [
         ...["a", "b", "c"].map((id) => ({
           id,
           data: getCardDataByConstId("shizukanaishi"),
@@ -3531,7 +3531,7 @@ describe("drawCardsOnTurnStart", () => {
   });
   test("1ターン目でレッスン開始時手札が8枚ある時、手札は最終的にレッスン開始時手札のみの5枚になり、山札の先頭3枚はレッスン開始時手札である", () => {
     const lesson = createLessonForTest({
-      deck: [
+      cards: [
         ...["a", "b", "c"].map((id) => ({
           id,
           data: getCardDataByConstId("shizukanaishi"),
@@ -3572,7 +3572,7 @@ describe("drawCardsOnTurnStart", () => {
   });
   test("全てのスキルカードへ付与しているレッスンサポートを削除する", () => {
     const lesson = createLessonForTest({
-      deck: [
+      cards: [
         ...["a", "b", "c"].map((id) => ({
           id,
           data: getCardDataByConstId("apirunokihon"),
@@ -3807,7 +3807,7 @@ describe("useCard preview:false", () => {
   describe("手札の消費", () => {
     test("「レッスン中1回」ではない手札を使った時は、捨札へ移動", () => {
       const lesson = createLessonForTest({
-        deck: [
+        cards: [
           {
             id: "a",
             data: getCardDataByConstId("apirunokihon"),
@@ -3830,7 +3830,7 @@ describe("useCard preview:false", () => {
     });
     test("「レッスン中1回」の手札を使った時は、除外へ移動", () => {
       const lesson = createLessonForTest({
-        deck: [
+        cards: [
           {
             id: "a",
             data: getCardDataByConstId("hyogennokihon"),
@@ -3856,7 +3856,7 @@ describe("useCard preview:false", () => {
   describe("コストの消費", () => {
     test("it works", () => {
       const lesson = createLessonForTest({
-        deck: [
+        cards: [
           {
             id: "a",
             data: getCardDataByConstId("apirunokihon"),
@@ -3891,7 +3891,7 @@ describe("useCard preview:false", () => {
     });
     test("状態修正により消費体力が変動", () => {
       const lesson = createLessonForTest({
-        deck: [
+        cards: [
           {
             id: "a",
             data: getCardDataByConstId("genkinaaisatsu"),
@@ -3921,7 +3921,7 @@ describe("useCard preview:false", () => {
   describe("Pアイテムに起因する、スキルカード使用時の主効果発動前の効果発動", () => {
     test("「アドレナリン全開」の使用により「最高にハッピーの源」が発動する", () => {
       let lesson = createLessonForTest({
-        deck: [
+        cards: [
           {
             id: "a",
             data: getCardDataByConstId("adorenarinzenkai"),
@@ -3991,7 +3991,7 @@ describe("useCard preview:false", () => {
   describe("状態修正に起因する、スキルカード使用時の効果発動", () => {
     test("「ファンシーチャーム」は、メンタルスキルカード使用時、好印象を付与する。アクティブスキルカード使用時は付与しない", () => {
       let lesson = createLessonForTest({
-        deck: [
+        cards: [
           {
             id: "a",
             data: getCardDataByConstId("fanshichamu"),
@@ -4075,7 +4075,7 @@ describe("useCard preview:false", () => {
     });
     test("「演出計画」は、アクティブスキルカード使用時、固定元気を付与する。メンタルスキルカード使用時は付与しない", () => {
       let lesson = createLessonForTest({
-        deck: [
+        cards: [
           {
             id: "a",
             data: getCardDataByConstId("enshutsukeikaku"),
@@ -4153,7 +4153,7 @@ describe("useCard preview:false", () => {
     });
     test("「輝くキミへ」を発動できる", () => {
       let lesson = createLessonForTest({
-        deck: [
+        cards: [
           {
             id: "a",
             data: getCardDataByConstId("kagayakukimihe"),
@@ -4224,7 +4224,7 @@ describe("useCard preview:false", () => {
     describe("効果適用条件を満たさない効果は適用されない", () => {
       test("「飛躍」は、集中が足りない時、パラメータ上昇は1回のみ適用する", () => {
         const lesson = createLessonForTest({
-          deck: [
+          cards: [
             {
               id: "a",
               data: getCardDataByConstId("hiyaku"),
@@ -4245,7 +4245,7 @@ describe("useCard preview:false", () => {
     describe("「次に使用するスキルカードの効果をもう1回発動」が付与されている時", () => {
       test("コスト消費は1回のみだが、選択したスキルカードの効果を2回発動し、2回目の効果には1回目の状態修正が反映されていて、追加でdoubleEffectを消費する更新を生成する", () => {
         const lesson = createLessonForTest({
-          deck: [
+          cards: [
             {
               id: "a",
               data: getCardDataByConstId("jumbiundo"),
@@ -4300,7 +4300,7 @@ describe("useCard preview:false", () => {
     describe("drawCards", () => {
       test("「アイドル宣言」を、山札が足りる・手札最大枚数を超えない状況で使った時、手札が2枚増え、捨札は不変で、除外が1枚増える / handWhenEmptyDeck の更新を発行しない", () => {
         const lesson = createLessonForTest({
-          deck: [
+          cards: [
             {
               id: "a",
               data: getCardDataByConstId("aidorusengen"),
@@ -4335,7 +4335,7 @@ describe("useCard preview:false", () => {
       });
       test("「アイドル宣言」を、山札が足りない状況で使った時、山札と捨札は再構築される / handWhenEmptyDeck を空にする更新を発行する", () => {
         const lesson = createLessonForTest({
-          deck: [
+          cards: [
             {
               id: "a",
               data: getCardDataByConstId("aidorusengen"),
@@ -4377,7 +4377,7 @@ describe("useCard preview:false", () => {
       });
       test("「アイドル宣言」を、手札最大枚数が超える状況で使った時、手札は最大枚数で、捨札が増える", () => {
         const lesson = createLessonForTest({
-          deck: [
+          cards: [
             {
               id: "a",
               data: getCardDataByConstId("aidorusengen"),
@@ -4411,7 +4411,7 @@ describe("useCard preview:false", () => {
     describe("enhanceHand", () => {
       test("「ティーパーティ」は、自分以外の、プロデュース中またはレッスン中に強化していない手札のみを強化する", () => {
         const lesson = createLessonForTest({
-          deck: [
+          cards: [
             {
               id: "a",
               data: getCardDataByConstId("teipatei"),
@@ -4451,7 +4451,7 @@ describe("useCard preview:false", () => {
     describe("exchangeHand", () => {
       test("「仕切り直し」を、手札3枚の状況で使った時、残りの手札は捨札へ入り、手札は山札から引いた新しい2枚になる", () => {
         const lesson = createLessonForTest({
-          deck: [
+          cards: [
             {
               id: "a",
               data: getCardDataByConstId("shikirinaoshi"),
@@ -4489,7 +4489,7 @@ describe("useCard preview:false", () => {
       });
       test("「仕切り直し」で山札の再構築が発生した時、handWhenEmptyDeckを空にする更新を発行する", () => {
         const lesson = createLessonForTest({
-          deck: [
+          cards: [
             {
               id: "a",
               data: getCardDataByConstId("shikirinaoshi"),
@@ -4523,7 +4523,7 @@ describe("useCard preview:false", () => {
       });
       test("「仕切り直し」で山札の再構築が発生しない時、handWhenEmptyDeckの更新を発行しない", () => {
         const lesson = createLessonForTest({
-          deck: [
+          cards: [
             {
               id: "a",
               data: getCardDataByConstId("shikirinaoshi"),
@@ -4552,7 +4552,7 @@ describe("useCard preview:false", () => {
     describe("getModifier", () => {
       test("新規追加の時", () => {
         const lesson = createLessonForTest({
-          deck: [
+          cards: [
             {
               id: "a",
               data: getCardDataByConstId("furumainokihon"),
@@ -4588,7 +4588,7 @@ describe("useCard preview:false", () => {
       });
       test("既存の状態修正と合算の時", () => {
         const lesson = createLessonForTest({
-          deck: [
+          cards: [
             {
               id: "a",
               data: getCardDataByConstId("furumainokihon"),
@@ -4621,7 +4621,7 @@ describe("useCard preview:false", () => {
       });
       test("既存の状態修正が存在しても新規追加になる状態修正の時", () => {
         const lesson = createLessonForTest({
-          deck: [
+          cards: [
             {
               id: "a",
               data: getCardDataByConstId("enshutsukeikaku"),
@@ -4673,7 +4673,7 @@ describe("useCard preview:false", () => {
     describe("perform", () => {
       test("レッスンにスコア上限がある時、スコアはそれを超えない増加値を返す", () => {
         const lesson = createLessonForTest({
-          deck: [
+          cards: [
             {
               id: "a",
               data: getCardDataByConstId("apirunokihon"),
@@ -4705,7 +4705,7 @@ describe("useCard preview:false", () => {
       });
       test("クリアスコアの設定だけありパーフェクトの設定がない時、レッスンにスコア上限はないと判断する", () => {
         const lesson = createLessonForTest({
-          deck: [
+          cards: [
             {
               id: "a",
               data: getCardDataByConstId("apirunokihon"),
@@ -4735,7 +4735,7 @@ describe("useCard preview:false", () => {
       });
       test("スコアボーナスの設定を反映する", () => {
         const lesson = createLessonForTest({
-          deck: [
+          cards: [
             {
               id: "a",
               data: getCardDataByConstId("apirunokihon"),
@@ -4764,7 +4764,7 @@ describe("useCard preview:false", () => {
       });
       test("複数の更新を生成するスコア増加を返す", () => {
         const lesson = createLessonForTest({
-          deck: [
+          cards: [
             {
               id: "a",
               data: getCardDataByConstId("shikosakugo"),
@@ -4797,7 +4797,7 @@ describe("useCard preview:false", () => {
       });
       test("スコアと元気の更新を同時に返す", () => {
         const lesson = createLessonForTest({
-          deck: [
+          cards: [
             {
               id: "a",
               data: getCardDataByConstId("pozunokihon"),
@@ -4834,7 +4834,7 @@ describe("useCard preview:false", () => {
     describe("performLeveragingModifier", () => {
       test("motivation", () => {
         const lesson = createLessonForTest({
-          deck: [
+          cards: [
             {
               id: "a",
               data: getCardDataByConstId("kaika"),
@@ -4860,7 +4860,7 @@ describe("useCard preview:false", () => {
       });
       test("positiveImpression", () => {
         const lesson = createLessonForTest({
-          deck: [
+          cards: [
             {
               id: "a",
               data: getCardDataByConstId("200sumairu"),
@@ -4888,7 +4888,7 @@ describe("useCard preview:false", () => {
       });
       test("スコア上限の設定がある時は、actualはその値を超えない", () => {
         const lesson = createLessonForTest({
-          deck: [
+          cards: [
             {
               id: "a",
               data: getCardDataByConstId("kaika"),
@@ -4919,7 +4919,7 @@ describe("useCard preview:false", () => {
     describe("performLeveragingVitality", () => {
       test("通常", () => {
         const lesson = createLessonForTest({
-          deck: [
+          cards: [
             {
               id: "a",
               data: getCardDataByConstId("genkinaaisatsu"),
@@ -4945,7 +4945,7 @@ describe("useCard preview:false", () => {
       });
       test("50%の元気を消費、端数は切り捨て", () => {
         const lesson = createLessonForTest({
-          deck: [
+          cards: [
             {
               id: "a",
               data: getCardDataByConstId("hatonoaizu"),
@@ -4971,7 +4971,7 @@ describe("useCard preview:false", () => {
       });
       test("100%の元気を消費", () => {
         const lesson = createLessonForTest({
-          deck: [
+          cards: [
             {
               id: "a",
               data: getCardDataByConstId("todoite"),
@@ -5001,7 +5001,7 @@ describe("useCard preview:false", () => {
   describe("Pアイテムに起因する、スキルカード使用時の主効果発動後の効果発動", () => {
     test("「えいえいおー」の使用により「テクノドッグ」が発動する", () => {
       let lesson = createLessonForTest({
-        deck: [
+        cards: [
           {
             id: "a",
             data: getCardDataByConstId("eieio"),
@@ -5058,7 +5058,7 @@ describe("useCard preview:false", () => {
   describe("Pアイテムに起因する、スキルカードの主効果による状態修正増加後の効果発動", () => {
     test("「意識の基本」の使用により「ひみつ特訓カーデ」が発動する", () => {
       let lesson = createLessonForTest({
-        deck: [
+        cards: [
           {
             id: "a",
             data: getCardDataByConstId("ishikinokihon"),
@@ -5114,7 +5114,7 @@ describe("useCard preview:false", () => {
   describe("スキルカード使用数追加によるアクションポイントの回復", () => {
     test("it works", () => {
       const lesson = createLessonForTest({
-        deck: [
+        cards: [
           {
             id: "a",
             data: getCardDataByConstId("hidamarinoseitokaishitsu"),
@@ -5176,7 +5176,7 @@ describe("useCard preview:false", () => {
   describe("handWhenEmptyDeckへの影響", () => {
     test("山札が0枚で、捨札になるスキルカードを使う時、handWhenEmptyDeckへそれを含めた手札を追加する", () => {
       const lesson = createLessonForTest({
-        deck: [
+        cards: [
           {
             id: "a",
             data: getCardDataByConstId("apirunokihon"),
@@ -5220,7 +5220,7 @@ describe("useCard preview:false", () => {
     });
     test("山札が0枚ではなく、捨札になるスキルカードを使う時、handWhenEmptyDeckへそれを追加しない", () => {
       const lesson = createLessonForTest({
-        deck: [
+        cards: [
           {
             id: "a",
             data: getCardDataByConstId("apirunokihon"),
@@ -5247,7 +5247,7 @@ describe("useCard preview:false", () => {
     });
     test("山札が0枚で、除外になるスキルカードを使う時、handWhenEmptyDeckへそれを追加しない", () => {
       const lesson = createLessonForTest({
-        deck: [
+        cards: [
           {
             id: "a",
             data: getCardDataByConstId("iji"),
@@ -5272,7 +5272,7 @@ describe("useCard preview:false", () => {
 describe("useCard preview:true", () => {
   test("コストに対してリソースが不足している時も、プレビューできる", () => {
     const lesson = createLessonForTest({
-      deck: [
+      cards: [
         {
           id: "a",
           data: getCardDataByConstId("apirunokihon"),
@@ -5307,7 +5307,7 @@ describe("useCard preview:true", () => {
   });
   test("コスト以外のスキルカード使用条件を満たさない時も、プレビューできる", () => {
     const lesson = createLessonForTest({
-      deck: [
+      cards: [
         {
           id: "a",
           data: getCardDataByConstId("chosen"),
@@ -5333,7 +5333,7 @@ describe("useCard preview:true", () => {
   });
   test("doubleEffectの効果を反映する", () => {
     const lesson = createLessonForTest({
-      deck: [
+      cards: [
         {
           id: "a",
           data: getCardDataByConstId("apirunokihon"),

--- a/src/lesson-mutation.ts
+++ b/src/lesson-mutation.ts
@@ -257,7 +257,7 @@ export const canPlayCard = (
       switch (valueKind) {
         case "life": {
           targetPercentage = Math.floor(
-            (lesson.idol.life * 100) / lesson.idol.original.maxLife,
+            (lesson.idol.life * 100) / lesson.idol.maxLife,
           );
           break;
         }
@@ -360,7 +360,7 @@ export const canActivateEffect = (
     }
     case "measureIfLifeIsEqualGreaterThanHalf": {
       const percentage = Math.floor(
-        (lesson.idol.life * 100) / lesson.idol.original.maxLife,
+        (lesson.idol.life * 100) / lesson.idol.maxLife,
       );
       return percentage >= 50;
     }
@@ -835,7 +835,7 @@ export const activateEffect = <
     // TODO: 手札5枚で生成した場合、現在は捨札に入れているが、本家は山札の先頭へスタックされる、Ref: https://youtu.be/40E2XOr0q2w
     case "generateCard": {
       const candidates = filterGeneratableCardsData(
-        lesson.idol.original.data.producePlan.kind,
+        lesson.idol.data.producePlan.kind,
       );
       const cardData =
         candidates[getRandomInteger(getRandom, candidates.length - 1)];
@@ -1108,10 +1108,7 @@ export const activateEffect = <
     case "recoverLife": {
       diffs.push({
         kind: "life",
-        actual: Math.min(
-          effect.value,
-          lesson.idol.original.maxLife - lesson.idol.life,
-        ),
+        actual: Math.min(effect.value, lesson.idol.maxLife - lesson.idol.life),
         max: effect.value,
       });
       break;

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -13,7 +13,6 @@ import {
   createCurrentTurnDetails,
   calculateModifierEffectedActionCost,
   createActualTurns,
-  createIdolInProduction,
   createGamePlay,
   diffUpdates,
   findPrioritizedDoubleEffectModifier,
@@ -338,9 +337,10 @@ describe("createActualTurns", () => {
   );
 });
 describe("createGamePlay", () => {
-  test("it creates a lesson game play", () => {
+  test("it works", () => {
     const idGenerator = createIdGenerator();
-    const idolInProduction = createIdolInProduction({
+    const gamePlay = createGamePlay({
+      idGenerator: createIdGenerator(),
       idolDataId: "hanamisaki-r-1",
       producerItems: [
         {
@@ -350,11 +350,6 @@ describe("createGamePlay", () => {
       ],
       specialTrainingLevel: 1,
       talentAwakeningLevel: 1,
-      idGenerator,
-    });
-    const gamePlay = createGamePlay({
-      idGenerator,
-      idolInProduction,
       turns: ["vocal", "vocal", "vocal", "vocal", "vocal", "vocal"],
     });
     expect(gamePlay).toStrictEqual({
@@ -363,7 +358,10 @@ describe("createGamePlay", () => {
       initialLesson: {
         clearScoreThresholds: undefined,
         idol: {
-          original: idolInProduction,
+          original: {
+            data: getIdolDataByConstId("hanamisaki-r-1"),
+            maxLife: 32,
+          },
           life: 32,
           vitality: 0,
           producerItems: expect.any(Array),
@@ -390,36 +388,6 @@ describe("createGamePlay", () => {
         ignoreIdolParameterKindConditionAfterClearing: false,
       },
       updates: [],
-    });
-  });
-});
-describe("createIdolInProduction", () => {
-  test("it creates an idol in production", () => {
-    const idGenerator = createIdGenerator();
-    const idolInProduction = createIdolInProduction({
-      idolDataId: "hanamisaki-r-1",
-      specialTrainingLevel: 1,
-      talentAwakeningLevel: 1,
-      idGenerator,
-    });
-    expect(idolInProduction).toStrictEqual({
-      deck: [
-        {
-          id: expect.any(String),
-          data: getCardDataByConstId("shinshinkiei"),
-          enhanced: false,
-        },
-      ],
-      data: getIdolDataByConstId("hanamisaki-r-1"),
-      life: 32,
-      maxLife: 32,
-      producerItems: [
-        {
-          id: expect.any(String),
-          data: getProducerItemDataByConstId("bakuonraion"),
-          enhanced: false,
-        },
-      ],
     });
   });
 });

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -358,11 +358,9 @@ describe("createGamePlay", () => {
       initialLesson: {
         clearScoreThresholds: undefined,
         idol: {
-          original: {
-            data: getIdolDataByConstId("hanamisaki-r-1"),
-            maxLife: 32,
-          },
+          data: getIdolDataByConstId("hanamisaki-r-1"),
           life: 32,
+          maxLife: 32,
           vitality: 0,
           producerItems: expect.any(Array),
           modifiers: [],

--- a/src/models.ts
+++ b/src/models.ts
@@ -233,7 +233,6 @@ export const isScoreSatisfyingPerfect = (lesson: Lesson): boolean => {
  * @param params.additionalCards アイドル固有に加えて、追加するスキルカードリスト
  * @param params.additionalProducerItems アイドル固有に加えて、追加するPアイテムリスト
  * @param params.cards テスト用、山札全体を明示的に指定する、アイドル固有を生成しないなど本来の処理を通さない
- * @param params.idGenerator createIdolInProduction で使用した関数と同じものを渡す
  * @param params.idolSpecificCardTestId テスト用、内部的なIDを指定する
  * @param params.producerItems テスト用、Pアイテム全体を指定する、アイドル固有を生成しないなど本来の処理を通さない
  * @param params.specialTrainingLevel 特訓段階、0 から 6

--- a/src/models.ts
+++ b/src/models.ts
@@ -316,15 +316,12 @@ export const createGamePlay = (params: {
       hand: [],
       idol: {
         actionPoints: 0,
+        data: idolData,
         drinks: params.drinks ?? [],
         life,
+        maxLife,
         modifierIdsAtTurnStart: [],
         modifiers: [],
-        // TODO: IdolInProduction 概念の名残なので、解体する
-        original: {
-          data: idolData,
-          maxLife,
-        },
         producerItems,
         scoreBonus: params.scoreBonus,
         totalCardUsageCount: 0,

--- a/src/models.ts
+++ b/src/models.ts
@@ -25,8 +25,6 @@ import {
   GetRandom,
   IdGenerator,
   Idol,
-  IdolData,
-  IdolInProduction,
   IdolParameterKind,
   Lesson,
   GamePlay,

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -8,7 +8,6 @@ import type {
 } from "./types";
 import { type IdolDataId } from "./data/idols";
 import {
-  createIdolInProduction,
   createGamePlay,
   getNextHistoryResultIndex,
   patchDiffs,
@@ -26,26 +25,20 @@ export const createGamePlayForTest = (
     turns?: Lesson["turns"];
   } = {},
 ): GamePlay => {
-  const clearScoreThresholds = options.clearScoreThresholds;
   // R広は、Pアイテムが最終ターンにならないと発動しないので、テストデータとして優秀
   const idolDataId = options.idolDataId ?? "shinosawahiro-r-1";
   const turns = options.turns ?? ["vocal", "vocal", "vocal", "vocal", "vocal"];
   const specialTrainingLevel = options.specialTrainingLevel ?? 1;
   const talentAwakeningLevel = options.talentAwakeningLevel ?? 1;
-  const idGenerator = createIdGenerator();
-  const idolInProduction = createIdolInProduction({
-    idGenerator,
+  return createGamePlay({
+    clearScoreThresholds: options.clearScoreThresholds,
+    idGenerator: createIdGenerator(),
     idolDataId,
+    turns,
     specialTrainingLevel,
     talentAwakeningLevel,
-    ...(options.deck ? { deck: options.deck } : {}),
+    ...(options.deck ? { cards: options.deck } : {}),
     ...(options.producerItems ? { producerItems: options.producerItems } : {}),
-  });
-  return createGamePlay({
-    clearScoreThresholds,
-    idGenerator,
-    idolInProduction,
-    turns,
   });
 };
 

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -17,7 +17,7 @@ import { createIdGenerator } from "./utils";
 export const createGamePlayForTest = (
   options: {
     clearScoreThresholds?: Lesson["clearScoreThresholds"];
-    deck?: CardInProduction[];
+    cards?: CardInProduction[];
     idolDataId?: IdolDataId;
     producerItems?: ProducerItemInProduction[];
     specialTrainingLevel?: number | undefined;
@@ -37,7 +37,7 @@ export const createGamePlayForTest = (
     turns,
     specialTrainingLevel,
     talentAwakeningLevel,
-    ...(options.deck ? { cards: options.deck } : {}),
+    ...(options.cards ? { cards: options.cards } : {}),
     ...(options.producerItems ? { producerItems: options.producerItems } : {}),
   });
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1192,7 +1192,10 @@ export type Idol = {
    */
   modifierIdsAtTurnStart: Array<Modifier["id"]>;
   modifiers: Modifier[];
-  original: IdolInProduction;
+  original: {
+    data: IdolData;
+    maxLife: number;
+  };
   /**
    * Pアイテムリスト
    *

--- a/src/types.ts
+++ b/src/types.ts
@@ -779,7 +779,7 @@ export type CardInProduction = Readonly<{
   data: CardData;
   enhanced: boolean;
   /**
-   * IdolInProduction["cards"] 内で一意のID
+   * Idol["cards"] 内で一意のID
    *
    * - 本番では、常に IdGenerator で生成する
    * - テストでは、IdGenerator 生成と被らない任意の値の設定が可能
@@ -1036,7 +1036,7 @@ export type ProducerItemInProduction = Readonly<{
   data: ProducerItemData;
   enhanced?: boolean;
   /**
-   * IdolInProduction["producerItems"] 内で一意のID
+   * Idol["producerItems"] 内で一意のID
    *
    * - 本番では、常に IdGenerator で生成する
    * - テストでは、IdGenerator 生成と被らない任意の値の設定が可能
@@ -1139,28 +1139,6 @@ export type IdolData = Readonly<{
 }>;
 
 /**
- * プロデュース中のプロデュースアイドル
- *
- * - プロデュース開始時に生成され、プロデュース終了時に破棄される
- */
-export type IdolInProduction = Readonly<{
-  data: IdolData;
-  deck: CardInProduction[];
-  // NOTE: まだ使わないので一旦コメントアウト
-  // idolParameters: IdolParameters;
-  life: number;
-  maxLife: number;
-  /**
-   * Pアイテムリスト
-   *
-   * - 上からプロデュース中に取得した順になる
-   *   - 参考動画: https://www.youtube.com/live/DDZaGs2xkNo?si=5bPmJB51PRPnODv_&t=2245
-   *     - たくさんPアイテムを取得しているプレイなのでわかりやすい
-   */
-  producerItems: ProducerItemInProduction[];
-}>;
-
-/**
  * レッスン中のプロデュースアイドル
  *
  * - レッスン開始前に生成され、レッスン終了時に破棄される
@@ -1197,9 +1175,11 @@ export type Idol = {
   /**
    * Pアイテムリスト
    *
-   * - 上からプロデュース中に取得した順になり、かつレッスン中に使える可能性のあるもののみに絞り込まれる
+   * - 上からプロデュース中に取得した順になる
    *   - 参考動画: https://www.youtube.com/live/DDZaGs2xkNo?si=5bPmJB51PRPnODv_&t=2245
    *     - たくさんPアイテムを取得しているプレイなのでわかりやすい
+   * - 本家では、レッスン中に使える可能性があるものだけ表示されているが、本実装では一旦は考慮しない
+   *   - 主にシミュレーター用途で、その際は設定画面込みでそちらで調整できるから
    */
   producerItems: ProducerItem[];
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1177,6 +1177,7 @@ export type Idol = {
    *   - 「ターン終了フラグ」も考えたが、コンテストで複数のアイドルがいる状況を考えると、アイドル側に持たせた方が良さそう
    */
   actionPoints: number;
+  data: IdolData;
   /**
    * Pドリンクリスト
    *
@@ -1184,6 +1185,7 @@ export type Idol = {
    */
   drinks: Drink[];
   life: number;
+  maxLife: number;
   /**
    * ターン開始時に付与されている状態修正IDリスト
    *
@@ -1192,10 +1194,6 @@ export type Idol = {
    */
   modifierIdsAtTurnStart: Array<Modifier["id"]>;
   modifiers: Modifier[];
-  original: {
-    data: IdolData;
-    maxLife: number;
-  };
   /**
    * Pアイテムリスト
    *


### PR DESCRIPTION
- `〜InProduction` は、育成ゲーム部分も実装しようとしていた時の名残なので、一律不要
- `CardInProduction` と `ProducerItemInProduction` がまだ残っている