### PR TITLE
テキスト生成ロジックを公開する

### DIFF
--- a/src/display.test.ts
+++ b/src/display.test.ts
@@ -6,6 +6,7 @@ import type {
   LessonDisplay,
   Modifier,
   ModifierDisplay,
+  ProducerItemDisplay,
 } from "./types";
 import { getCardDataByConstId } from "./data/cards";
 import { getDrinkDataByConstId } from "./data/drinks";
@@ -17,6 +18,7 @@ import {
   generateEncouragementDisplays,
   generateLessonDisplay,
   generateModifierDisplays,
+  generateProducerItemDisplays,
 } from "./display";
 import { createIdGenerator } from "./utils";
 import { createGamePlayForTest, createLessonForTest } from "./test-utils";
@@ -1353,5 +1355,43 @@ describe("generateModifierDisplays", () => {
   ];
   test.each(testCases)("$name", ({ args, expected }) => {
     expect(generateModifierDisplays(...args)).toMatchObject(expected);
+  });
+});
+describe("generateProducerItemDisplays", () => {
+  const testCases: Array<{
+    args: Parameters<typeof generateProducerItemDisplays>;
+    expected: ReturnType<typeof generateProducerItemDisplays>;
+    name: string;
+  }> = [
+    {
+      name: "name - 強化状態を反映する",
+      args: [
+        [
+          {
+            id: "p1",
+            data: getProducerItemDataByConstId("saigononatsunoomoide"),
+            enhanced: true,
+            activationCount: 0,
+          },
+          {
+            id: "p2",
+            data: getProducerItemDataByConstId("amakawaramemmeguri"),
+            enhanced: false,
+            activationCount: 0,
+          },
+        ],
+      ],
+      expected: [
+        {
+          name: "最後の夏の思い出+",
+        },
+        {
+          name: "天川ラーメン巡り",
+        },
+      ] as ProducerItemDisplay[],
+    },
+  ];
+  test.each(testCases)("$name", ({ args, expected }) => {
+    expect(generateProducerItemDisplays(...args)).toMatchObject(expected);
   });
 });

--- a/src/display.ts
+++ b/src/display.ts
@@ -23,6 +23,7 @@ import type {
   TurnDisplay,
   Modifier,
   ProducePlan,
+  ProducerItem,
 } from "./types";
 import { compareDeckOrder } from "./data/cards";
 import { metaModifierDictioanry } from "./data/modifiers";
@@ -49,6 +50,7 @@ import {
   generateDrinkDescription,
   generateEffectText,
   generateProducerItemDescription,
+  generateProducerItemName,
   idolParameterKindNames,
 } from "./text-generation";
 
@@ -190,11 +192,11 @@ export const generateCardInInventoryDisplays = (
 };
 
 export const generateProducerItemDisplays = (
-  lesson: Lesson,
+  producerItems: ProducerItem[],
 ): ProducerItemDisplay[] => {
-  return lesson.idol.producerItems.map((producerItem) => {
+  return producerItems.map((producerItem) => {
     const producerItemContent = getProducerItemContentData(producerItem);
-    const name = producerItem.data.name + (producerItem.enhanced ? "+" : "");
+    const name = generateProducerItemName(producerItem);
     return {
       ...producerItem,
       name,
@@ -377,7 +379,7 @@ export const generateLessonDisplay = (gamePlay: GamePlay): LessonDisplay => {
       lesson.idol.maxLife - lesson.idol.life,
     ),
     modifiers,
-    producerItems: generateProducerItemDisplays(lesson),
+    producerItems: generateProducerItemDisplays(lesson.idol.producerItems),
     score: lesson.score,
     scoreBonus,
     turns,

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,7 @@ export {
   generateLessonDisplay,
   generateCardPlayPreviewDisplay,
 } from "./display";
+export * from "./text-generation";
 export * from "./models";
 export * from "./utils";
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -136,24 +136,6 @@ export const getDisplayedRepresentativeModifierValue = <
 };
 
 /**
- * 初期スキルカードセットを生成する
- */
-export const createDefaultCardSet = (
-  producePlan: ProducePlan,
-  idGenerator: IdGenerator,
-): Card[] => {
-  const defaultCardSetData = getDefaultCardSetData(producePlan);
-  return defaultCardSetData.cardDataIds.map((cardDataId) => {
-    const cardData = getCardDataById(cardDataId);
-    return {
-      id: idGenerator(),
-      data: cardData,
-      enhancements: [],
-    };
-  });
-};
-
-/**
  * レッスンのクリアに対するスコア進捗を計算する
  */
 export const calculateClearScoreProgress = (

--- a/src/text-generation.ts
+++ b/src/text-generation.ts
@@ -25,6 +25,7 @@ import type {
   VitalityUpdateQuery,
   DrinkData,
   EffectWithoutCondition,
+  ProducerItem,
 } from "./types";
 import { metaModifierDictioanry } from "./data/modifiers";
 
@@ -443,6 +444,12 @@ export const generateCardDescription = (params: {
   }
   return lines.join("\n");
 };
+
+/**
+ * Pアイテム名を生成する
+ */
+export const generateProducerItemName = (producerItem: ProducerItem): string =>
+  producerItem.data.name + (producerItem.enhanced ? "+" : "");
 
 export const generateProducerItemTriggerAndConditionText = (params: {
   condition?: EffectCondition;


### PR DESCRIPTION
- Close: https://github.com/kjirou/gakumas-core/issues/168
- 具体的には、単体でスキルカード名・Pアイテム名を生成するロジックがシミュレーター側で必要になったため
