### PR TITLE
使用したスキルカード数を数えていなかった

### DIFF
--- a/src/display.test.ts
+++ b/src/display.test.ts
@@ -145,6 +145,30 @@ describe("generateCardInHandDisplay", () => {
       } as CardInHandDisplay,
     },
     {
+      name: "使用したスキルカード数を参照して元気を増加する効果は、まだ使っていないスキルカードを1枚分として加算した上で、表示値へ反映する",
+      args: [
+        (() => {
+          const lesson = createLessonForTest({
+            cards: [
+              {
+                id: "a",
+                data: getCardDataByConstId("mikannotaiki"),
+                enhancements: [],
+              },
+            ],
+          });
+          lesson.idol.totalCardUsageCount = 2;
+          return lesson;
+        })(),
+        "a",
+        () => 0,
+        createIdGenerator(),
+      ],
+      expected: {
+        vitality: 11,
+      } as CardInHandDisplay,
+    },
+    {
       name: "無条件の状態修正と条件付きの状態修正を持つスキルカードで、後者の条件を満たさない時、effectsには条件を満たした旨と満たさない旨の2レコードが入る",
       args: [
         createLessonForTest({
@@ -637,6 +661,11 @@ describe("generateCardPlayPreviewDisplay", () => {
             kind: "life",
             actual: -3,
             max: -3,
+            reason: expect.any(Object),
+          },
+          {
+            kind: "totalCardUsageCount",
+            value: 1,
             reason: expect.any(Object),
           },
           {

--- a/src/display.ts
+++ b/src/display.ts
@@ -95,13 +95,21 @@ export const generateCardInHandDisplay = (
   getRandom: GetRandom,
   idGenerator: IdGenerator,
 ): CardInHandDisplay => {
-  const card = lesson.cards.find((card) => card.id === cardId);
+  let newLesson = lesson;
+  // 使用したスキルカード数は、1加算された状態で表示される
+  newLesson = patchDiffs(lesson, [
+    {
+      kind: "totalCardUsageCount",
+      value: newLesson.idol.totalCardUsageCount + 1,
+    },
+  ]);
+  const card = newLesson.cards.find((card) => card.id === cardId);
   if (!card) {
     throw new Error(`Card not found in cards: cardId=${cardId}`);
   }
   const cardContent = getCardContentData(card.data, card.enhancements.length);
   const effectActivations = activateEffectsOnCardPlay(
-    lesson,
+    newLesson,
     cardContent.effects,
     getRandom,
     idGenerator,
@@ -144,12 +152,12 @@ export const generateCardInHandDisplay = (
   return {
     cost: calculateModifierEffectedActionCost(
       cardContent.cost,
-      lesson.idol.modifiers,
+      newLesson.idol.modifiers,
     ),
     effects: effectDisplays,
     enhancements: card.enhancements,
     name: generateCardName(card.data.name, card.enhancements.length),
-    playable: canPlayCard(lesson, cardContent.cost, cardContent.condition),
+    playable: canPlayCard(newLesson, cardContent.cost, cardContent.condition),
     rarity: card.data.rarity,
     scores,
     vitality,

--- a/src/lesson-mutation.ts
+++ b/src/lesson-mutation.ts
@@ -2294,6 +2294,26 @@ export const useCard = (
   nextHistoryResultIndex++;
 
   //
+  // 使用したスキルカード数を加算
+  //
+  const totalCardUsageCountUpdates: LessonUpdateQuery[] = [
+    createLessonUpdateQueryFromDiff(
+      {
+        kind: "totalCardUsageCount",
+        value: newLesson.idol.totalCardUsageCount + 1,
+      },
+      {
+        kind: "cardUsage.totalCardUsageCount",
+        cardId: card.id,
+        historyTurnNumber: newLesson.turnNumber,
+        historyResultIndex: nextHistoryResultIndex,
+      },
+    ),
+  ];
+  newLesson = patchDiffs(newLesson, totalCardUsageCountUpdates);
+  nextHistoryResultIndex++;
+
+  //
   // 効果発動
   //
   let effectActivationUpdates: LessonUpdateQuery[] = [];
@@ -2533,6 +2553,7 @@ export const useCard = (
       ...consumeRemainingCardUsageCountUpdates,
       ...usedCardPlacementUpdates,
       ...costConsumptionUpdates,
+      ...totalCardUsageCountUpdates,
       ...effectActivationUpdates,
       ...recoveringActionPointsUpdates,
     ],

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -1190,6 +1190,19 @@ describe("patchDiffs", () => {
       expect(lessonMock.score).toBe(3);
     });
   });
+  describe("totalCardUsageCount", () => {
+    test("it works", () => {
+      let lessonMock = {
+        idol: {
+          totalCardUsageCount: 0,
+        },
+      } as Lesson;
+      lessonMock = patchDiffs(lessonMock, [
+        { kind: "totalCardUsageCount", value: 2 },
+      ]);
+      expect(lessonMock.idol.totalCardUsageCount).toBe(2);
+    });
+  });
   describe("turnEnded", () => {
     test("it works", () => {
       let lessonMock = {

--- a/src/models.ts
+++ b/src/models.ts
@@ -640,6 +640,16 @@ export const patchDiffs = <LessonUpdateDiffLike extends LessonUpdateDiff>(
         };
         break;
       }
+      case "totalCardUsageCount": {
+        newLesson = {
+          ...newLesson,
+          idol: {
+            ...newLesson.idol,
+            totalCardUsageCount: update.value,
+          },
+        };
+        break;
+      }
       case "turnEnded": {
         newLesson = {
           ...newLesson,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1165,7 +1165,13 @@ export type Idol = {
    *   - 検証: https://github.com/kjirou/gakumas-core/issues/81
    */
   scoreBonus: Record<IdolParameterKind, number> | undefined;
-  /** 本レッスン中にスキルカードを使用した回数、関連する原文は「レッスン中に使用したスキルカード{n}枚ごとに、」 */
+  /**
+   * 使用したスキルカード数
+   *
+   * - 関連する原文は、「レッスン中に使用したスキルカード{n}枚ごとに、」
+   * - スキルカードの効果がこの値を参照する場合、そのスキルカードを使用した分も1回分として加算する
+   *   - 仕様確認: https://github.com/kjirou/gakumas-core/issues/203
+   */
   totalCardUsageCount: number;
   /**
    * 元気
@@ -1539,6 +1545,11 @@ export type LessonUpdateQueryReason = Readonly<
     | {
         /** スキルカード使用.残りスキルカード使用数消費 */
         kind: "cardUsage.remainingCardUsageCountConsumption";
+      }
+    | {
+        /** スキルカード使用.使用したスキルカード数 */
+        kind: "cardUsage.totalCardUsageCount";
+        cardId: Card["id"];
       }
     | {
         /** Pドリンク使用.消費 */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1425,6 +1425,10 @@ export type LessonUpdateDiff = Readonly<
       max: number;
     }
   | {
+      kind: "totalCardUsageCount";
+      value: number;
+    }
+  | {
       kind: "turnEnded";
       value: boolean;
     }


### PR DESCRIPTION
- データの定義だけしていたが、数える処理が完全に未実装だった
- Fix: https://github.com/kjirou/gakumas-core/issues/199
- 仕様確認: https://github.com/kjirou/gakumas-core/issues/203